### PR TITLE
#1/implement text component

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,4 @@
 nodeLinker: node-modules
+nmHoistingLimits: dependencies
 
 yarnPath: .yarn/releases/yarn-4.9.2.cjs

--- a/packages/design-system/src/components/Text/Text.stories.tsx
+++ b/packages/design-system/src/components/Text/Text.stories.tsx
@@ -1,5 +1,6 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Text } from "./Text";
+import { Props } from "./Text.types";
 
 const meta: Meta<typeof Text> = {
   title: "components/Text",
@@ -60,7 +61,7 @@ export const Headings: Story = {
   args: {
     children: "제목 텍스트"
   },
-  render: args => (
+  render: (args: Props) => (
     <>
       <Text {...args} $size="h1">
         Heading 1
@@ -88,7 +89,7 @@ export const BodyTexts: Story = {
   args: {
     children: "본문 텍스트"
   },
-  render: args => (
+  render: (args: Props) => (
     <>
       <Text {...args} $size="body1">
         Body Text 1 - 기본 본문 텍스트 스타일
@@ -111,19 +112,11 @@ export const WithCustomColor: Story = {
   }
 };
 
-export const WithAlignment: Story = {
-  args: {
-    $size: "body1",
-    $align: "center",
-    children: "가운데 정렬 텍스트"
-  }
-};
-
 export const FontWeight: Story = {
   args: {
-    children: "폰트 굵기 텍스트"
+    children: "폰트 굵기별 텍스트"
   },
-  render: args => (
+  render: (args: Props) => (
     <>
       <Text {...args} $size="body1" $weight="regular">
         Regular Weight Text
@@ -140,7 +133,7 @@ export const FontWeight: Story = {
 
 export const SpanElement: Story = {
   args: {
-    $size: "h1",
+    $size: "h4",
     $span: true,
     children: "Span으로 렌더링된 텍스트"
   }

--- a/packages/design-system/src/components/Text/Text.stories.tsx
+++ b/packages/design-system/src/components/Text/Text.stories.tsx
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Text } from "./Text";
+
+const meta: Meta<typeof Text> = {
+  title: "components/Text",
+  component: Text,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered"
+  },
+  argTypes: {
+    $size: {
+      control: "select",
+      options: [
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "body1",
+        "body2",
+        "caption"
+      ],
+      description: "텍스트 크기 및 HTML 태그"
+    },
+    $weight: {
+      control: "select",
+      options: ["regular", "medium", "bold"],
+      description: "폰트 굵기"
+    },
+    $color: {
+      control: "color",
+      description: "텍스트 색상"
+    },
+    $align: {
+      control: "select",
+      options: ["left", "center", "right"],
+      description: "텍스트 정렬"
+    },
+    $span: {
+      control: "boolean",
+      description: "span 태그로 렌더링"
+    }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Text>;
+
+export const Default: Story = {
+  args: {
+    $size: "body1",
+    children: "기본 텍스트"
+  }
+};
+
+export const Headings: Story = {
+  args: {
+    children: "제목 텍스트"
+  },
+  render: args => (
+    <>
+      <Text {...args} $size="h1">
+        Heading 1
+      </Text>
+      <Text {...args} $size="h2">
+        Heading 2
+      </Text>
+      <Text {...args} $size="h3">
+        Heading 3
+      </Text>
+      <Text {...args} $size="h4">
+        Heading 4
+      </Text>
+      <Text {...args} $size="h5">
+        Heading 5
+      </Text>
+      <Text {...args} $size="h6">
+        Heading 6
+      </Text>
+    </>
+  )
+};
+
+export const BodyTexts: Story = {
+  args: {
+    children: "본문 텍스트"
+  },
+  render: args => (
+    <>
+      <Text {...args} $size="body1">
+        Body Text 1 - 기본 본문 텍스트 스타일
+      </Text>
+      <Text {...args} $size="body2">
+        Body Text 2 - 보조 본문 텍스트 스타일
+      </Text>
+      <Text {...args} $size="caption">
+        Caption - 작은 설명 텍스트
+      </Text>
+    </>
+  )
+};
+
+export const WithCustomColor: Story = {
+  args: {
+    $size: "body1",
+    $color: "#ff0000",
+    children: "빨간색 텍스트"
+  }
+};
+
+export const WithAlignment: Story = {
+  args: {
+    $size: "body1",
+    $align: "center",
+    children: "가운데 정렬 텍스트"
+  }
+};
+
+export const FontWeight: Story = {
+  args: {
+    children: "폰트 굵기 텍스트"
+  },
+  render: args => (
+    <>
+      <Text {...args} $size="body1" $weight="regular">
+        Regular Weight Text
+      </Text>
+      <Text {...args} $size="body1" $weight="medium">
+        Medium Weight Text
+      </Text>
+      <Text {...args} $size="body1" $weight="bold">
+        Bold Weight Text
+      </Text>
+    </>
+  )
+};
+
+export const SpanElement: Story = {
+  args: {
+    $size: "h1",
+    $span: true,
+    children: "Span으로 렌더링된 텍스트"
+  }
+};

--- a/packages/design-system/src/components/Text/Text.test.tsx
+++ b/packages/design-system/src/components/Text/Text.test.tsx
@@ -1,0 +1,79 @@
+import { screen } from "@testing-library/react";
+import { expect, describe, it } from "vitest";
+import { Text } from "./Text";
+import { renderWithTheme } from "@/utils";
+
+describe("Text", () => {
+  it("renders children correctly", () => {
+    const testContent = "Test Content";
+    renderWithTheme(<Text $size="body1">{testContent}</Text>);
+    const textElement = screen.getByText(testContent);
+    expect(textElement).toBeInTheDocument();
+  });
+
+  it("renders as p element by default", () => {
+    renderWithTheme(<Text $size="body1">Content</Text>);
+    const textElement = screen.getByText("Content");
+    expect(textElement.tagName).toBe("P");
+  });
+
+  it("renders as heading element when size starts with h", () => {
+    renderWithTheme(<Text $size="h1">Content</Text>);
+    const textElement = screen.getByText("Content");
+    expect(textElement.tagName).toBe("H1");
+  });
+
+  it("renders as span when $span prop is true", () => {
+    renderWithTheme(
+      <Text $size="h1" $span>
+        Content
+      </Text>
+    );
+    const textElement = screen.getByText("Content");
+    expect(textElement.tagName).toBe("SPAN");
+  });
+
+  it("applies color correctly", () => {
+    const colorValue = "#ff0000";
+    renderWithTheme(
+      <Text $size="body1" $color={colorValue}>
+        Content
+      </Text>
+    );
+    const textElement = screen.getByText("Content");
+    expect(textElement).toHaveStyle(`color: ${colorValue}`);
+  });
+
+  it("applies text alignment correctly", () => {
+    renderWithTheme(
+      <Text $size="body1" $align="center">
+        Content
+      </Text>
+    );
+    const textElement = screen.getByText("Content");
+    expect(textElement).toHaveStyle("text-align: center");
+  });
+
+  it("applies font weight correctly", () => {
+    renderWithTheme(
+      <Text $size="body1" $weight="bold">
+        Content
+      </Text>
+    );
+    const textElement = screen.getByText("Content");
+    expect(textElement).toHaveStyle("font-weight: 700");
+  });
+
+  it("applies all props correctly", () => {
+    renderWithTheme(
+      <Text $size="h2" $color="#333333" $align="right" $weight="medium">
+        Content
+      </Text>
+    );
+
+    const textElement = screen.getByText("Content");
+    expect(textElement.tagName).toBe("H2");
+    expect(textElement).toHaveStyle("color: #333333");
+    expect(textElement).toHaveStyle("text-align: right");
+  });
+});

--- a/packages/design-system/src/components/Text/Text.tsx
+++ b/packages/design-system/src/components/Text/Text.tsx
@@ -19,7 +19,7 @@ const cache: Partial<Record<TextElement, ComponentType<Props>>> = {};
 const createComponent = (element: TextElement): TextComponent => {
   cache[element] = styled(element)<Props>`
     color: ${({ theme, $color }) =>
-      $color ? $color : theme.color.grayScale[10]};
+      $color ? $color : theme.color.grayScale[90]};
     font-weight: ${({ theme, $weight }) =>
       $weight ? theme.fontWeight[$weight] : theme.fontWeight.regular};
     font-size: ${({ theme, $size }) => theme.font[$size].fontSize};

--- a/packages/design-system/src/components/Text/Text.tsx
+++ b/packages/design-system/src/components/Text/Text.tsx
@@ -1,0 +1,49 @@
+import styled from "@emotion/styled";
+import type { Props } from "./Text.types";
+import type { TextProps } from "@/utils";
+import type { ComponentType } from "react";
+
+type TextElement = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
+type TextComponent = ComponentType<TextProps<Props>>;
+
+const parseSize = (size: Props["$size"], isSpan?: boolean): TextElement => {
+  if (isSpan) return "span";
+
+  if (size.startsWith("h")) return size as TextElement;
+
+  return "p";
+};
+
+const cache: Partial<Record<TextElement, ComponentType<Props>>> = {};
+
+const createComponent = (element: TextElement): TextComponent => {
+  cache[element] = styled(element)<Props>`
+    color: ${({ theme, $color }) =>
+      $color ? $color : theme.color.grayScale[10]};
+    font-weight: ${({ theme, $weight }) =>
+      $weight ? theme.fontWeight[$weight] : theme.fontWeight.regular};
+    font-size: ${({ theme, $size }) => theme.font[$size].fontSize};
+    line-height: ${({ theme, $size }) => theme.font[$size].lineHeight};
+    ${({ $align }) => $align && `text-align: ${$align};`}
+  `;
+  return cache[element] as TextComponent;
+};
+
+export const Text = ({
+  children,
+  $size,
+  $span,
+  $color,
+  $align,
+  $weight
+}: TextProps<Props>) => {
+  const element = parseSize($size, $span);
+
+  const Component = cache[element] || createComponent(element);
+
+  return (
+    <Component $size={$size} $color={$color} $align={$align} $weight={$weight}>
+      {children}
+    </Component>
+  );
+};

--- a/packages/design-system/src/components/Text/Text.types.ts
+++ b/packages/design-system/src/components/Text/Text.types.ts
@@ -1,0 +1,9 @@
+import type { JOBISTheme } from "@/themes";
+
+export interface Props {
+  $size: keyof JOBISTheme["font"];
+  $weight?: keyof JOBISTheme["fontWeight"];
+  $color?: string;
+  $span?: boolean;
+  $align?: "left" | "center" | "right" | "justify";
+}

--- a/packages/design-system/src/components/Text/index.ts
+++ b/packages/design-system/src/components/Text/index.ts
@@ -1,0 +1,1 @@
+export * from "./Text";

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./primitive";
 export * from "./MyComponent";
+export * from "./Text";

--- a/packages/design-system/src/components/primitive/Box/Box.stories.ts
+++ b/packages/design-system/src/components/primitive/Box/Box.stories.ts
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Box } from "./Box";
 
 const meta: Meta<typeof Box> = {

--- a/packages/design-system/src/components/primitive/Container/Container.stories.tsx
+++ b/packages/design-system/src/components/primitive/Container/Container.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Container } from "./Container";
 import { Box } from "@/components";
 

--- a/packages/design-system/src/components/primitive/Flex/Flex.stories.tsx
+++ b/packages/design-system/src/components/primitive/Flex/Flex.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Flex } from "./Flex";
 import { Box } from "@/components";
 

--- a/packages/design-system/src/components/primitive/Grid/Grid.stories.tsx
+++ b/packages/design-system/src/components/primitive/Grid/Grid.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Grid } from "./Grid";
 import { Box } from "@/components";
 

--- a/packages/design-system/src/components/primitive/Image/Image.stories.ts
+++ b/packages/design-system/src/components/primitive/Image/Image.stories.ts
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Image } from "./Image";
 
 const meta: Meta<typeof Image> = {

--- a/packages/design-system/src/components/primitive/Layer/Layer.stories.tsx
+++ b/packages/design-system/src/components/primitive/Layer/Layer.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Layer } from "./Layer";
 import { Box, Positioner } from "@/components";
 

--- a/packages/design-system/src/components/primitive/Positioner/Positioner.stories.tsx
+++ b/packages/design-system/src/components/primitive/Positioner/Positioner.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Positioner } from "./Positioner";
 import { Box } from "@/components";
 

--- a/packages/design-system/src/components/primitive/Spacer/Spacer.stories.tsx
+++ b/packages/design-system/src/components/primitive/Spacer/Spacer.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Spacer } from "./Spacer";
 import { Box, Flex } from "@/components";
 

--- a/packages/design-system/src/components/primitive/Stack/Stack.stories.tsx
+++ b/packages/design-system/src/components/primitive/Stack/Stack.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Stack } from "./Stack";
 import { Box } from "@/components";
 

--- a/packages/design-system/src/components/primitive/Surface/Surface.stories.tsx
+++ b/packages/design-system/src/components/primitive/Surface/Surface.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Surface } from "./Surface";
 import { Box } from "@/components";
 

--- a/packages/design-system/src/components/primitive/Visibility/Visibility.stories.tsx
+++ b/packages/design-system/src/components/primitive/Visibility/Visibility.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Visibility } from "./Visibility";
 import { Box } from "@/components";
 

--- a/packages/design-system/src/themes/GlobalStyles.tsx
+++ b/packages/design-system/src/themes/GlobalStyles.tsx
@@ -1,8 +1,9 @@
-import { Global, css, useTheme } from "@emotion/react";
+import { Global, css } from "@emotion/react";
+import { useTheme } from "@/hooks";
 import font from "../../assets/fonts/pretendard-variable.woff2";
 
 export const GlobalStyles = () => {
-  const theme = useTheme();
+  const { currentTheme } = useTheme();
   return (
     <Global
       styles={css`
@@ -28,7 +29,7 @@ export const GlobalStyles = () => {
             sans-serif;
           -webkit-font-smoothing: antialiased;
           -moz-osx-font-smoothing: grayscale;
-          background-color: ${theme.color.grayScale[10]};
+          background-color: ${currentTheme.color.grayScale[10]};
         }
       `}
     />

--- a/packages/design-system/src/utils/type.ts
+++ b/packages/design-system/src/utils/type.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 export type ParentProps<T extends object> = T & { children?: ReactNode };
+export type TextProps<T extends object> = T & { children?: string };
 export type PixelValue = number | `${number}px`;
 export type DimensionValue = PixelValue | `${number}%`;
 export type BorderValue =


### PR DESCRIPTION
## 작업 내용 설명
- Text 컴포넌트 구현

## 주요 변경 사항
- Text에 대한 컴포넌트, props, test, stories 파일 작성
- Text 계열 컴포넌트를 위한 TextProps 유틸 타입 추가
- ThemeProvider를 기반으로 theme을 가져오던 GlobalStyles가 zustand 기반 useTheme을 사용하도록 수정
- Storybook 관련 의존성이 분산되어 설치되던 문제점을 호이스팅 제한으로 해결

## 결과물
<img width="1044" height="726" alt="image" src="https://github.com/user-attachments/assets/25af3404-9b00-4be9-8f00-3c105a4f32e6" />

## 체크리스트
- [x] 빌드 되나요? (`yarn build`)
- [x] 콘솔에 에러 없나요? (`yarn dev`)
- [ ] 목표한 부분만 수정했나요? (사이드 이펙트 체크)

## 해결 이슈
- resolved #1 