### PR TITLE
#12/radio checkbox component

### DIFF
--- a/packages/design-system/.storybook/preview.ts
+++ b/packages/design-system/.storybook/preview.ts
@@ -15,6 +15,14 @@ const preview = definePreview({
     a11y: {
       test: "error"
     },
+    backgrounds: {
+      default: "light",
+      disable: true,
+      options: {
+        light: { name: "Light", value: "#fff" },
+        dark: { name: "Dark", value: "#000" }
+      }
+    },
     options: {
       storySort: {
         method: "alphabetical",

--- a/packages/design-system/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { Checkbox } from "./Checkbox";
+
+const meta: Meta<typeof Checkbox> = {
+  title: "components/Checkbox",
+  component: Checkbox,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered"
+  },
+  args: {
+    onChange: fn()
+  },
+  argTypes: {
+    label: {
+      control: "text",
+      description: "텍스트 라벨"
+    },
+    $checked: {
+      control: "boolean",
+      description: "체크박스 상태"
+    },
+    onChange: {
+      action: "changed",
+      description: "체크박스 상태 변경 이벤트"
+    }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Checkbox>;
+
+export const Default: Story = {
+  args: {
+    label: "Default Checkbox",
+    $checked: false
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const component = canvas.getByRole("checkbox");
+    expect(component).toBeInTheDocument();
+    await userEvent.click(component);
+    await expect(args.onChange).toHaveBeenCalledTimes(1);
+  }
+};
+
+export const Checked: Story = {
+  args: {
+    label: "Checked Checkbox",
+    $checked: true
+  }
+};
+
+export const Unchecked: Story = {
+  args: {
+    label: "Unchecked Checkbox",
+    $checked: false
+  }
+};
+
+export const WithoutLabel: Story = {
+  name: "Without Label",
+  args: {
+    $checked: false
+  }
+};

--- a/packages/design-system/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { expect, describe, it, vi } from "vitest";
+import { Checkbox } from "./Checkbox";
+import { renderWithTheme } from "@/utils";
+
+describe("Checkbox", () => {
+  it("renders correctly with default props", () => {
+    renderWithTheme(<Checkbox />);
+    const checkboxElement = screen.getByRole("checkbox");
+    expect(checkboxElement).toBeInTheDocument();
+    expect(checkboxElement).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("renders correctly when checked", () => {
+    renderWithTheme(<Checkbox $checked />);
+    const checkboxElement = screen.getByRole("checkbox");
+    expect(checkboxElement).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("renders label when provided", () => {
+    const label = "Test Label";
+    renderWithTheme(<Checkbox label={label} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it("calls onChange handler when clicked", () => {
+    const handleChange = vi.fn();
+    renderWithTheme(<Checkbox $checked={false} onChange={handleChange} />);
+    const checkboxElement = screen.getByRole("checkbox");
+    fireEvent.click(checkboxElement);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/design-system/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,94 @@
+import styled from "@emotion/styled";
+import { Text } from "@/components";
+import { type Props } from "./Checkbox.types";
+
+const Component = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  position: relative;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+
+  &:hover div::before {
+    transform: translate(-50%, -50%) scale(1);
+  }
+`;
+
+const StyledCheckbox = styled.div<Pick<Props, "$checked">>`
+  position: relative;
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  border: 2px solid
+    ${({ theme, $checked }) =>
+      $checked ? theme.color.primary[20] : theme.color.grayScale[40]};
+  background-color: ${({ theme, $checked }) =>
+    $checked ? theme.color.primary[20] : "transparent"};
+  transition:
+    border-color 0.2s ease-in-out,
+    background-color 0.2s ease-in-out;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background-color: ${({ theme }) => theme.color.subColor.blue[10]};
+    transform: translate(-50%, -50%) scale(0);
+    transition: transform 0.3s ease;
+    z-index: -1;
+  }
+`;
+
+const CheckIcon = styled.svg`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+`;
+
+export const Checkbox = ({ label, $checked = false, onChange }: Props) => {
+  const handleToggle = () => onChange?.(!$checked);
+
+  return (
+    <Component
+      type="button"
+      role="checkbox"
+      aria-checked={$checked}
+      onClick={handleToggle}
+    >
+      <StyledCheckbox $checked={$checked}>
+        {$checked && (
+          <CheckIcon
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M1.25 5.375L4.25 8.375L8.75 1.625"
+              stroke="white"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </CheckIcon>
+        )}
+      </StyledCheckbox>
+      {label && (
+        <Text $span $size="body1" $weight="regular">
+          {label}
+        </Text>
+      )}
+    </Component>
+  );
+};

--- a/packages/design-system/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/design-system/src/components/Checkbox/Checkbox.types.ts
@@ -1,0 +1,5 @@
+export interface Props {
+  label?: string;
+  $checked?: boolean;
+  onChange?: (value: boolean) => void;
+}

--- a/packages/design-system/src/components/Checkbox/index.ts
+++ b/packages/design-system/src/components/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export * from "./Checkbox";

--- a/packages/design-system/src/components/Radio/Radio.stories.tsx
+++ b/packages/design-system/src/components/Radio/Radio.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { Radio } from "./Radio";
+
+const meta: Meta<typeof Radio> = {
+  title: "components/Radio",
+  component: Radio,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered"
+  },
+  args: {
+    onChange: fn()
+  },
+  argTypes: {
+    label: {
+      control: "text",
+      description: "텍스트 라벨"
+    },
+    $checked: {
+      control: "boolean",
+      description: "라디오 상태"
+    },
+    onChange: {
+      action: "changed",
+      description: "라디오 상태 변경 이벤트"
+    }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Radio>;
+
+export const Default: Story = {
+  args: {
+    label: "Default Radio",
+    $checked: false
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const component = canvas.getByRole("radio");
+    expect(component).toBeInTheDocument();
+    await userEvent.click(component);
+    await expect(args.onChange).toHaveBeenCalledTimes(1);
+  }
+};
+
+export const Checked: Story = {
+  args: {
+    label: "Checked Radio",
+    $checked: true
+  }
+};
+
+export const Unchecked: Story = {
+  args: {
+    label: "Unchecked Radio",
+    $checked: false
+  }
+};
+
+export const WithoutLabel: Story = {
+  name: "Without Label",
+  args: {
+    $checked: false
+  }
+};

--- a/packages/design-system/src/components/Radio/Radio.test.tsx
+++ b/packages/design-system/src/components/Radio/Radio.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { expect, describe, it, vi } from "vitest";
+import { Radio } from "./Radio";
+import { renderWithTheme } from "@/utils";
+
+describe("Radio", () => {
+  it("renders correctly with default props", () => {
+    renderWithTheme(<Radio />);
+    const radioElement = screen.getByRole("radio");
+    expect(radioElement).toBeInTheDocument();
+    expect(radioElement).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("renders correctly when checked", () => {
+    renderWithTheme(<Radio $checked />);
+    const radioElement = screen.getByRole("radio");
+    expect(radioElement).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("renders label when provided", () => {
+    const label = "Test Label";
+    renderWithTheme(<Radio label={label} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it("calls onChange handler when clicked", () => {
+    const handleChange = vi.fn();
+    renderWithTheme(<Radio $checked={false} onChange={handleChange} />);
+    const radioElement = screen.getByRole("radio");
+    fireEvent.click(radioElement);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/design-system/src/components/Radio/Radio.tsx
+++ b/packages/design-system/src/components/Radio/Radio.tsx
@@ -1,0 +1,82 @@
+import styled from "@emotion/styled";
+import { Text } from "@/components";
+import { type Props } from "./Radio.types";
+
+const Component = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  position: relative;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+
+  &:hover div::before {
+    transform: translate(-50%, -50%) scale(1);
+  }
+`;
+
+const StyledRadio = styled.div<Pick<Props, "$checked">>`
+  position: relative;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid
+    ${({ theme, $checked }) =>
+      $checked ? theme.color.primary[20] : theme.color.grayScale[40]};
+  transition:
+    border-color 0.2s ease-in-out,
+    background-color 0.2s ease-in-out;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background-color: ${({ theme }) => theme.color.subColor.blue[10]};
+    transform: translate(-50%, -50%) scale(0);
+    transition: transform 0.3s ease;
+    z-index: -1;
+  }
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 12px;
+    height: 12px;
+    border-radius: 6px;
+    background-color: ${({ theme }) => theme.color.primary[20]};
+    transform: ${({ $checked }) =>
+      $checked
+        ? "translate(-50%, -50%) scale(1)"
+        : "translate(-50%, -50%) scale(0)"};
+    transition: transform 0.2s ease-in-out;
+  }
+`;
+
+export const Radio = ({ label, $checked = false, onChange }: Props) => {
+  const handleToggle = () => onChange?.(!$checked);
+
+  return (
+    <Component
+      type="button"
+      role="radio"
+      aria-checked={$checked}
+      onClick={handleToggle}
+    >
+      <StyledRadio $checked={$checked} />
+      {label && (
+        <Text $span $size="body1" $weight="regular">
+          {label}
+        </Text>
+      )}
+    </Component>
+  );
+};

--- a/packages/design-system/src/components/Radio/Radio.types.ts
+++ b/packages/design-system/src/components/Radio/Radio.types.ts
@@ -1,0 +1,5 @@
+export interface Props {
+  label?: string;
+  $checked?: boolean;
+  onChange?: (value: boolean) => void;
+}

--- a/packages/design-system/src/components/Radio/index.ts
+++ b/packages/design-system/src/components/Radio/index.ts
@@ -1,0 +1,1 @@
+export * from "./Radio";


### PR DESCRIPTION
## 작업 내용 설명
- Radio 컴포넌트 구현
- Checkbox 컴포넌트 구현

## 주요 변경 사항
- Radio, Checkbox에 대한 컴포넌트, props, test, stories 파일 작성
- Storybook의 background addon에서 배경색과 readonly설정을 추가하여 withCustomTheme 데코레이터와 일치한 동작을 보장

## 결과물
<img width="1029" height="507" alt="image" src="https://github.com/user-attachments/assets/fcc17e0f-d207-4448-8cf1-74d19a3b0e6e" />

<img width="1042" height="502" alt="image" src="https://github.com/user-attachments/assets/4d651f2d-d442-43b3-84b8-bee3bd298433" />

## 체크리스트
- [x] 빌드 되나요? (`yarn build`)
- [x] 콘솔에 에러 없나요? (`yarn dev`)
- [ ] 목표한 부분만 수정했나요? (사이드 이펙트 체크)

## 해결 이슈
- resolved #12 