### PR TITLE
#51/add-button-size

### DIFF
--- a/packages/design-system/src/components/Button/Button.stories.tsx
+++ b/packages/design-system/src/components/Button/Button.stories.tsx
@@ -75,6 +75,9 @@ export const Variants: Story = {
 export const Sizes: Story = {
   render: args => (
     <div style={{ display: "flex", alignItems: "center", gap: "16px" }}>
+      <Button {...args} $size="sm">
+        Small
+      </Button>
       <Button {...args} $size="md">
         Medium
       </Button>

--- a/packages/design-system/src/components/Button/Button.test.tsx
+++ b/packages/design-system/src/components/Button/Button.test.tsx
@@ -24,4 +24,10 @@ describe("Button", () => {
     const buttonElement = screen.getByRole("button", { name: /click me/i });
     expect(buttonElement).toBeDisabled();
   });
+
+  it("renders correctly with sm size", () => {
+    renderWithTheme(<Button $size="sm">Small Button</Button>);
+    const buttonElement = screen.getByRole("button", { name: /small button/i });
+    expect(buttonElement).toBeInTheDocument();
+  });
 });

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -43,19 +43,26 @@ const Component = styled.button<Props>`
 
   ${({ $size = "md" }) => {
     switch ($size) {
-      case "md":
-        return `
-          height: 48px;
-          padding: 0 40px;
-          font-size: 16px;
-          border-radius: 8px;
-        `;
       case "lg":
         return `
-          height: 48px;
-          padding: 0 147px;
-          font-size: 16px;
-          border-radius: 12px;
+        height: 48px;
+        padding: 0 147px;
+        font-size: 16px;
+        border-radius: 12px;
+        `;
+      case "md":
+        return `
+            height: 48px;
+            padding: 0 40px;
+            font-size: 16px;
+            border-radius: 8px;
+            `;
+      case "sm":
+        return `
+              height:36px;
+              padding: 8px 12px;
+              border-radius: 8px;
+              font-size: 14px;              
         `;
     }
   }}

--- a/packages/design-system/src/components/Button/Button.types.ts
+++ b/packages/design-system/src/components/Button/Button.types.ts
@@ -1,7 +1,7 @@
 import { type ComponentPropsWithoutRef } from "react";
 
 export const buttonVariants = ["contained", "outline"] as const;
-export const buttonSizes = ["md", "lg"] as const;
+export const buttonSizes = ["lg", "md", "sm"] as const;
 
 export type ButtonVariant = (typeof buttonVariants)[number];
 export type ButtonSize = (typeof buttonSizes)[number];


### PR DESCRIPTION
## 작업 내용 설명
버튼 sm 사이즈 추가

## 주요 변경 사항
버튼 sm 사이즈 추가

## 결과물
<img width="2818" height="582" alt="image" src="https://github.com/user-attachments/assets/f52fd092-6a13-4bd1-b789-165e715a24a0" />


## 체크리스트
- [x] 빌드 되나요? (`yarn build`)
- [x] 콘솔에 에러 없나요? (`yarn dev`)
- [x] 목표한 부분만 수정했나요? (사이드 이펙트 체크)

## 해결 이슈
- resolved #51 