### PR TITLE
#77/query key factory and cache method export

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -9,6 +9,11 @@
     "preview": "vite preview",
     "lint": "eslint ."
   },
+  "dependencies": {
+    "@jobis/api": "workspace:*",
+    "@jobis/design-system": "workspace:*",
+    "@jobis/sentry": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^24.2.1",
     "typescript": "5.8.3",

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,24 +1,13 @@
 {
   "extends": "../../tsconfig.app.json",
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@jobis/design-system": ["../../packages/design-system/src/index"],
-      "@jobis/api": ["../../packages/api/src/index"],
-      "@jobis/sentry": ["../../packages/sentry/src/index"]
-    },
+    "baseUrl": "../../",
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "references": [
-    {
-      "path": "../../packages/design-system",
-    },
-    {
-      "path": "../../packages/api"
-    },
-    {
-      "path": "../../packages/sentry"
-    }
+    { "path": "../../packages/api" },
+    { "path": "../../packages/design-system" },
+    { "path": "../../packages/sentry" }
   ]
 }

--- a/apps/company/package.json
+++ b/apps/company/package.json
@@ -9,6 +9,11 @@
     "preview": "vite preview",
     "lint": "eslint ."
   },
+  "dependencies": {
+    "@jobis/api": "workspace:*",
+    "@jobis/design-system": "workspace:*",
+    "@jobis/sentry": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^24.2.1",
     "typescript": "5.8.3",

--- a/apps/company/tsconfig.json
+++ b/apps/company/tsconfig.json
@@ -1,24 +1,13 @@
 {
   "extends": "../../tsconfig.app.json",
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@jobis/design-system": ["../../packages/design-system/src/index"],
-      "@jobis/api": ["../../packages/api/src/index"],
-      "@jobis/sentry": ["../../packages/sentry/src/index"]
-    },
+    "baseUrl": "../../",
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "references": [
-    {
-      "path": "../../packages/design-system"
-    },
-    {
-      "path": "../../packages/api"
-    },
-    {
-      "path": "../../packages/sentry"
-    }
+    { "path": "../../packages/api" },
+    { "path": "../../packages/design-system" },
+    { "path": "../../packages/sentry" }
   ]
 }

--- a/apps/student/package.json
+++ b/apps/student/package.json
@@ -9,6 +9,11 @@
     "preview": "vite preview",
     "lint": "eslint ."
   },
+  "dependencies": {
+    "@jobis/api": "workspace:*",
+    "@jobis/design-system": "workspace:*",
+    "@jobis/sentry": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^24.2.1",
     "typescript": "5.8.3",

--- a/apps/student/tsconfig.json
+++ b/apps/student/tsconfig.json
@@ -1,24 +1,13 @@
 {
   "extends": "../../tsconfig.app.json",
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@jobis/design-system": ["../../packages/design-system/src/index"],
-      "@jobis/api": ["../../packages/api/src/index"],
-      "@jobis/sentry": ["../../packages/sentry/src/index"]
-    },
+    "baseUrl": "../../",
     "outDir": "dist"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "references": [
-    {
-      "path": "../../packages/design-system"
-    },
-    {
-      "path": "../../packages/api"
-    },
-    {
-      "path": "../../packages/sentry"
-    }
+    { "path": "../../packages/api" },
+    { "path": "../../packages/design-system" },
+    { "path": "../../packages/sentry" }
   ]
 }

--- a/nx.json
+++ b/nx.json
@@ -16,6 +16,11 @@
     ],
     "sharedGlobals": []
   },
+  "targetDefaults": {
+    "build": {
+      "dependsOn": ["^build"]
+    }
+  },
   "plugins": [
     {
       "plugin": "@nx/js/typescript",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "scripts": {
     "build": "nx build",
-    "build:many": "nx run-many -t build",
+    "build:many": "nx run-many -t build --parallel=3",
     "build:affected": "nx affected -t build",
     "graph": "nx run-many --target=build --graph",
     "prepare": "husky",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,8 +3,14 @@
   "version": "0.0.0",
   "main": "dist/index.js",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && tsc -b --force",
     "lint": "eslint .",
     "type-check": "tsc --noEmit"
   },

--- a/packages/api/src/QueryProvider.ts
+++ b/packages/api/src/QueryProvider.ts
@@ -27,6 +27,20 @@ const client = new QueryClient({
   }
 });
 
+export const query = {
+  async prefetch(queryKey: unknown[]) {
+    await client.prefetchQuery({
+      queryKey
+    });
+  },
+  async invalidate(queryKey: unknown[]) {
+    await client.invalidateQueries({ queryKey });
+  },
+  remove(queryKey: unknown[]) {
+    client.removeQueries({ queryKey });
+  }
+} as const;
+
 export const QueryProvider = ({ children }: { children: ReactNode }) => {
   return createElement(QueryClientProvider, { client }, children);
 };

--- a/packages/api/src/acceptances/index.ts
+++ b/packages/api/src/acceptances/index.ts
@@ -6,17 +6,20 @@ import type {
   CreateEmploymentRequest,
   DeleteAcceptanceRequest
 } from "./types";
-import type { QueryOptions, MutationOptions } from "@/QueryProvider";
+import { QueryOptions, MutationOptions } from "@/QueryProvider";
 import { instance } from "@/instance";
+import { acceptancesKeys } from "./keys";
 
 const DOMAIN = "/acceptances";
 
+export { acceptancesKeys };
+
 export const useAcceptanceDetail = (
   companyId: number,
-  options: QueryOptions<AcceptanceDetailResponse>
+  options?: QueryOptions<AcceptanceDetailResponse>
 ) => {
   return useQuery({
-    queryKey: ["acceptance-detail", companyId],
+    queryKey: acceptancesKeys.acceptanceDetail(companyId),
     queryFn: async () => {
       const { data } = await instance.get<AcceptanceDetailResponse>(
         `${DOMAIN}/${companyId}`

--- a/packages/api/src/acceptances/index.ts
+++ b/packages/api/src/acceptances/index.ts
@@ -6,7 +6,7 @@ import type {
   CreateEmploymentRequest,
   DeleteAcceptanceRequest
 } from "./types";
-import { QueryOptions, MutationOptions } from "@/QueryProvider";
+import { QueryOptions, MutationOptions } from "../QueryProvider";
 import { instance } from "@/instance";
 import { acceptancesKeys } from "./keys";
 

--- a/packages/api/src/acceptances/keys.ts
+++ b/packages/api/src/acceptances/keys.ts
@@ -1,0 +1,3 @@
+export const acceptancesKeys = {
+  acceptanceDetail: (companyId: number) => ["acceptance-detail", companyId]
+} as const;

--- a/packages/api/src/applications/index.ts
+++ b/packages/api/src/applications/index.ts
@@ -11,14 +11,17 @@ import type {
 } from "./types";
 import type { QueryOptions, MutationOptions } from "@/QueryProvider";
 import { instance } from "@/instance";
+import { applicationsKeys } from "./keys";
 
 const DOMAIN = "/applications";
+
+export { applicationsKeys };
 
 export const useEmploymentCount = (
   options?: QueryOptions<EmploymentCountResponse>
 ) => {
   return useQuery({
-    queryKey: ["employment-count"],
+    queryKey: applicationsKeys.employmentCount(),
     queryFn: async () => {
       const { data } = await instance.get<EmploymentCountResponse>(
         `${DOMAIN}/employment/count`
@@ -34,7 +37,7 @@ export const usePass = (
   options?: QueryOptions<PassResponse>
 ) => {
   return useQuery({
-    queryKey: ["pass", companyId],
+    queryKey: applicationsKeys.pass(companyId),
     queryFn: async () => {
       const { data } = await instance.get<PassResponse>(
         `${DOMAIN}/pass/${companyId}`
@@ -49,7 +52,7 @@ export const useCompanyApplications = (
   options?: QueryOptions<CompanyApplicationResponse>
 ) => {
   return useQuery({
-    queryKey: ["company-applications"],
+    queryKey: applicationsKeys.companyApplications(),
     queryFn: async () => {
       const { data } = await instance.get<CompanyApplicationResponse>(
         `${DOMAIN}/company`
@@ -64,7 +67,7 @@ export const useStudentApplications = (
   options?: QueryOptions<StudentApplicationResponse>
 ) => {
   return useQuery({
-    queryKey: ["student-applications"],
+    queryKey: applicationsKeys.studentApplications(),
     queryFn: async () => {
       const { data } = await instance.get<StudentApplicationResponse>(
         `${DOMAIN}/students`
@@ -85,15 +88,14 @@ export const useTeacherApplications = (
   options?: QueryOptions<TeacherApplicationResponse>
 ) => {
   return useQuery({
-    queryKey: [
-      "teacher-applications",
+    queryKey: applicationsKeys.teacherApplications(
       applicationStatus,
       studentName,
       recruitmentId,
       winterIntern,
       page,
       year
-    ],
+    ),
     queryFn: async () => {
       const { data } = await instance.get<TeacherApplicationResponse>(
         `${DOMAIN}`,
@@ -120,7 +122,10 @@ export const useTeacherApplicationCount = (
   options?: QueryOptions<TeacherApplicationCountResponse>
 ) => {
   return useQuery({
-    queryKey: ["teacher-application-count", applicationStatus, studentName],
+    queryKey: applicationsKeys.teacherApplicationCount(
+      applicationStatus,
+      studentName
+    ),
     queryFn: async () => {
       const { data } = await instance.get<TeacherApplicationCountResponse>(
         `${DOMAIN}/teacher/count`,
@@ -219,7 +224,7 @@ export const useRejection = (
   options?: QueryOptions<RejectionResponse>
 ) => {
   return useQuery({
-    queryKey: ["rejection", applicationId],
+    queryKey: applicationsKeys.rejection(applicationId),
     queryFn: async () => {
       const { data } = await instance.get<RejectionResponse>(
         `${DOMAIN}/rejection/${applicationId}`
@@ -251,14 +256,13 @@ export const useApplicationCount = (
   options?: QueryOptions<{ count: number }>
 ) => {
   return useQuery({
-    queryKey: [
-      "application-count",
+    queryKey: applicationsKeys.applicationCount(
       applicationStatus,
       studentName,
       recruitmentId,
       winterIntern,
       year
-    ],
+    ),
     queryFn: async () => {
       const { data } = await instance.get<{ count: number }>(
         `${DOMAIN}/count`,
@@ -291,7 +295,7 @@ export const useDeleteApplications = (options?: MutationOptions<string>) => {
 
 export const useEmployment = (options?: QueryOptions<EmploymentResponse>) => {
   return useQuery({
-    queryKey: ["employment"],
+    queryKey: applicationsKeys.employment(),
     queryFn: async () => {
       const { data } = await instance.get<EmploymentResponse>(
         `${DOMAIN}/employment`

--- a/packages/api/src/applications/keys.ts
+++ b/packages/api/src/applications/keys.ts
@@ -1,0 +1,42 @@
+export const applicationsKeys = {
+  employmentCount: () => ["employment-count"],
+  pass: (companyId: number) => ["pass", companyId],
+  companyApplications: () => ["company-applications"],
+  studentApplications: () => ["student-applications"],
+  teacherApplications: (
+    applicationStatus?: string,
+    studentName?: string,
+    recruitmentId?: number,
+    winterIntern?: boolean,
+    page?: number,
+    year?: string
+  ) => [
+    "teacher-applications",
+    applicationStatus,
+    studentName,
+    recruitmentId,
+    winterIntern,
+    page,
+    year
+  ],
+  teacherApplicationCount: (
+    applicationStatus?: string,
+    studentName?: string
+  ) => ["teacher-application-count", applicationStatus, studentName],
+  rejection: (applicationId: number) => ["rejection", applicationId],
+  applicationCount: (
+    applicationStatus?: string,
+    studentName?: string,
+    recruitmentId?: number,
+    winterIntern?: boolean,
+    year?: string
+  ) => [
+    "application-count",
+    applicationStatus,
+    studentName,
+    recruitmentId,
+    winterIntern,
+    year
+  ],
+  employment: () => ["employment"]
+} as const;

--- a/packages/api/src/banners/index.ts
+++ b/packages/api/src/banners/index.ts
@@ -6,8 +6,11 @@ import type {
 } from "./types";
 import type { QueryOptions, MutationOptions } from "@/QueryProvider";
 import { instance } from "@/instance";
+import { bannersKeys } from "./keys";
 
 const DOMAIN = "/banners";
+
+export { bannersKeys };
 
 export const useCreateBanner = (
   options?: MutationOptions<CreateBannerRequest>
@@ -33,7 +36,7 @@ export const useDeleteBanner = (
 
 export const useBannerList = (options?: QueryOptions<BannerListResponse>) => {
   return useQuery({
-    queryKey: ["banner-list"],
+    queryKey: bannersKeys.bannerList(),
     queryFn: async () => {
       const { data } = await instance.get<BannerListResponse>(DOMAIN);
       return data;
@@ -47,7 +50,7 @@ export const useTeacherBannerList = (
   options?: QueryOptions<TeacherBannerListResponse>
 ) => {
   return useQuery({
-    queryKey: ["teacher-banner-list", isOpened],
+    queryKey: bannersKeys.teacherBannerList(isOpened),
     queryFn: async () => {
       const { data } = await instance.get<TeacherBannerListResponse>(
         `${DOMAIN}/teacher`,

--- a/packages/api/src/banners/keys.ts
+++ b/packages/api/src/banners/keys.ts
@@ -1,0 +1,4 @@
+export const bannersKeys = {
+  bannerList: () => ["banner-list"],
+  teacherBannerList: (isOpened?: boolean) => ["teacher-banner-list", isOpened]
+} as const;

--- a/packages/api/src/bookmarks/index.ts
+++ b/packages/api/src/bookmarks/index.ts
@@ -2,12 +2,15 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import type { BookmarksResponse } from "./types";
 import type { QueryOptions, MutationOptions } from "@/QueryProvider";
 import { instance } from "@/instance";
+import { bookmarksKeys } from "./keys";
 
 const DOMAIN = "/bookmarks";
 
+export { bookmarksKeys };
+
 export const useBookmarks = (options?: QueryOptions<BookmarksResponse>) => {
   return useQuery({
-    queryKey: ["bookmarks"],
+    queryKey: bookmarksKeys.bookmarks(),
     queryFn: async () => {
       const { data } = await instance.get<BookmarksResponse>(DOMAIN);
       return data;

--- a/packages/api/src/bookmarks/keys.ts
+++ b/packages/api/src/bookmarks/keys.ts
@@ -1,0 +1,3 @@
+export const bookmarksKeys = {
+  bookmarks: () => ["bookmarks"]
+} as const;

--- a/packages/api/src/codes/index.ts
+++ b/packages/api/src/codes/index.ts
@@ -6,8 +6,11 @@ import type {
 } from "./types";
 import type { QueryOptions, MutationOptions } from "@/QueryProvider";
 import { instance } from "@/instance";
+import { codesKeys } from "./keys";
 
 const DOMAIN = "/codes";
+
+export { codesKeys };
 
 export const useCodeList = (
   type: string,
@@ -16,7 +19,7 @@ export const useCodeList = (
   options?: QueryOptions<CodeListResponse>
 ) => {
   return useQuery({
-    queryKey: ["code-list", type, keyword, parentCode],
+    queryKey: codesKeys.codeList(type, keyword, parentCode),
     queryFn: async () => {
       const { data } = await instance.get<CodeListResponse>(DOMAIN, {
         params: { type, keyword, parent_code: parentCode }

--- a/packages/api/src/codes/keys.ts
+++ b/packages/api/src/codes/keys.ts
@@ -1,0 +1,8 @@
+export const codesKeys = {
+  codeList: (type: string, keyword?: string, parentCode?: number) => [
+    "code-list",
+    type,
+    keyword,
+    parentCode
+  ]
+} as const;

--- a/packages/api/src/companies/index.ts
+++ b/packages/api/src/companies/index.ts
@@ -20,8 +20,11 @@ import type {
 } from "./types";
 import type { QueryOptions, MutationOptions } from "@/QueryProvider";
 import { instance } from "@/instance";
+import { companiesKeys } from "./keys";
 
 const DOMAIN = "/companies";
+
+export { companiesKeys };
 
 export const useCompanyStudentList = (
   page?: number,
@@ -29,7 +32,7 @@ export const useCompanyStudentList = (
   options?: QueryOptions<CompanyStudentListResponse>
 ) => {
   return useQuery({
-    queryKey: ["company-student-list", page, name],
+    queryKey: companiesKeys.companyStudentList(page, name),
     queryFn: async () => {
       const { data } = await instance.get<CompanyStudentListResponse>(
         `${DOMAIN}/student`,
@@ -46,7 +49,7 @@ export const useCompanyStudentCount = (
   options?: QueryOptions<CompanyStudentCountResponse>
 ) => {
   return useQuery({
-    queryKey: ["company-student-count", name],
+    queryKey: companiesKeys.companyStudentCount(name),
     queryFn: async () => {
       const { data } = await instance.get<CompanyStudentCountResponse>(
         `${DOMAIN}/student/count`,
@@ -62,7 +65,7 @@ export const useCompanyReviewList = (
   options?: QueryOptions<CompanyReviewListResponse>
 ) => {
   return useQuery({
-    queryKey: ["company-review-list"],
+    queryKey: companiesKeys.companyReviewList(),
     queryFn: async () => {
       const { data } = await instance.get<CompanyReviewListResponse>(
         `${DOMAIN}/review`
@@ -78,7 +81,7 @@ export const useCompanyDetail = (
   options?: QueryOptions<CompanyDetailResponse>
 ) => {
   return useQuery({
-    queryKey: ["company-detail", companyId],
+    queryKey: companiesKeys.companyDetail(companyId),
     queryFn: async () => {
       const { data } = await instance.get<CompanyDetailResponse>(
         `${DOMAIN}/${companyId}`
@@ -91,7 +94,7 @@ export const useCompanyDetail = (
 
 export const useCompanyMy = (options?: QueryOptions<CompanyMyResponse>) => {
   return useQuery({
-    queryKey: ["company-my"],
+    queryKey: companiesKeys.companyMy(),
     queryFn: async () => {
       const { data } = await instance.get<CompanyMyResponse>(`${DOMAIN}/my`);
       return data;
@@ -132,7 +135,7 @@ export const useCompanyExists = (
   options?: QueryOptions<CompanyExistsResponse>
 ) => {
   return useQuery({
-    queryKey: ["company-exists", businessNumber],
+    queryKey: companiesKeys.companyExists(businessNumber),
     queryFn: async () => {
       const { data } = await instance.get<CompanyExistsResponse>(
         `${DOMAIN}/exists/${businessNumber}`
@@ -161,7 +164,13 @@ export const useTeacherCompanyList = (
   options?: QueryOptions<TeacherCompanyListResponse>
 ) => {
   return useQuery({
-    queryKey: ["teacher-company-list", page, type, name, region, businessArea],
+    queryKey: companiesKeys.teacherCompanyList(
+      page,
+      type,
+      name,
+      region,
+      businessArea
+    ),
     queryFn: async () => {
       const { data } = await instance.get<TeacherCompanyListResponse>(
         `${DOMAIN}/teacher`,
@@ -182,7 +191,13 @@ export const useTeacherCompanyCount = (
   options?: QueryOptions<TeacherCompanyCountResponse>
 ) => {
   return useQuery({
-    queryKey: ["teacher-company-count", page, type, name, region, businessArea],
+    queryKey: companiesKeys.teacherCompanyCount(
+      page,
+      type,
+      name,
+      region,
+      businessArea
+    ),
     queryFn: async () => {
       const { data } = await instance.get<TeacherCompanyCountResponse>(
         `${DOMAIN}/teacher/count`,
@@ -202,7 +217,12 @@ export const useEmploymentCompanyList = (
   options?: QueryOptions<EmploymentCompanyListResponse>
 ) => {
   return useQuery({
-    queryKey: ["employment-company-list", page, companyName, companyType, year],
+    queryKey: companiesKeys.employmentCompanyList(
+      page,
+      companyName,
+      companyType,
+      year
+    ),
     queryFn: async () => {
       const { data } = await instance.get<EmploymentCompanyListResponse>(
         `${DOMAIN}/employment`,
@@ -228,7 +248,11 @@ export const useEmploymentCompanyCount = (
   options?: QueryOptions<EmploymentCompanyCountResponse>
 ) => {
   return useQuery({
-    queryKey: ["employment-company-count", companyName, companyType, year],
+    queryKey: companiesKeys.employmentCompanyCount(
+      companyName,
+      companyType,
+      year
+    ),
     queryFn: async () => {
       const { data } = await instance.get<EmploymentCompanyCountResponse>(
         `${DOMAIN}/employment/count`,
@@ -261,7 +285,7 @@ export const useCompanyCount = (
   options?: QueryOptions<CompanyCountResponse>
 ) => {
   return useQuery({
-    queryKey: ["company-count", type, name, region, businessArea],
+    queryKey: companiesKeys.companyCount(type, name, region, businessArea),
     queryFn: async () => {
       const { data } = await instance.get<CompanyCountResponse>(
         `${DOMAIN}/count`,
@@ -277,7 +301,7 @@ export const useCompanyCount = (
 
 export const useCompanyFileDownload = (options?: QueryOptions<Blob>) => {
   return useQuery({
-    queryKey: ["company-file"],
+    queryKey: companiesKeys.companyFileDownload(),
     queryFn: async () => {
       const { data } = await instance.get<Blob>(`${DOMAIN}/file`, {
         responseType: "blob"

--- a/packages/api/src/companies/keys.ts
+++ b/packages/api/src/companies/keys.ts
@@ -1,0 +1,44 @@
+export const companiesKeys = {
+  companyStudentList: (page?: number, name?: string) => [
+    "company-student-list",
+    page,
+    name
+  ],
+  companyStudentCount: (name?: string) => ["company-student-count", name],
+  companyReviewList: () => ["company-review-list"],
+  companyDetail: (companyId: number) => ["company-detail", companyId],
+  companyMy: () => ["company-my"],
+  companyExists: (businessNumber: string) => ["company-exists", businessNumber],
+  teacherCompanyList: (
+    page?: number,
+    type?: string,
+    name?: string,
+    region?: string,
+    businessArea?: number
+  ) => ["teacher-company-list", page, type, name, region, businessArea],
+  teacherCompanyCount: (
+    page?: number,
+    type?: string,
+    name?: string,
+    region?: string,
+    businessArea?: number
+  ) => ["teacher-company-count", page, type, name, region, businessArea],
+  employmentCompanyList: (
+    page?: number,
+    companyName?: string,
+    companyType?: string,
+    year?: number
+  ) => ["employment-company-list", page, companyName, companyType, year],
+  employmentCompanyCount: (
+    companyName?: string,
+    companyType?: string,
+    year?: number
+  ) => ["employment-company-count", companyName, companyType, year],
+  companyCount: (
+    type?: string,
+    name?: string,
+    region?: string,
+    businessArea?: number
+  ) => ["company-count", type, name, region, businessArea],
+  companyFileDownload: () => ["company-file"]
+} as const;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./config";
 export * from "./enum";
-export { QueryProvider } from "./QueryProvider";
+export { QueryProvider, query } from "./QueryProvider";
 export { setToken, resetToken, setCookie, removeCookie } from "./instance";
 
 export * from "./acceptances";

--- a/packages/api/src/notices/index.ts
+++ b/packages/api/src/notices/index.ts
@@ -7,8 +7,11 @@ import type {
 } from "./types";
 import type { QueryOptions, MutationOptions } from "@/QueryProvider";
 import { instance } from "@/instance";
+import { noticesKeys } from "./keys";
 
 const DOMAIN = "/notices";
+
+export { noticesKeys };
 
 export const useCreateNotice = (
   options?: MutationOptions<CreateNoticeRequest>
@@ -49,7 +52,7 @@ export const useNoticeDetail = (
   options?: QueryOptions<NoticeDetailResponse>
 ) => {
   return useQuery({
-    queryKey: ["notice-detail", noticeId],
+    queryKey: noticesKeys.noticeDetail(noticeId),
     queryFn: async () => {
       const { data } = await instance.get<NoticeDetailResponse>(
         `${DOMAIN}/${noticeId}`
@@ -62,7 +65,7 @@ export const useNoticeDetail = (
 
 export const useNoticeList = (options?: QueryOptions<NoticeListResponse>) => {
   return useQuery({
-    queryKey: ["notice-list"],
+    queryKey: noticesKeys.noticeList(),
     queryFn: async () => {
       const { data } = await instance.get<NoticeListResponse>(DOMAIN);
       return data;

--- a/packages/api/src/notices/keys.ts
+++ b/packages/api/src/notices/keys.ts
@@ -1,0 +1,4 @@
+export const noticesKeys = {
+  noticeDetail: (noticeId: number) => ["notice-detail", noticeId],
+  noticeList: () => ["notice-list"]
+} as const;

--- a/packages/api/src/notifications/index.ts
+++ b/packages/api/src/notifications/index.ts
@@ -5,15 +5,18 @@ import type {
 } from "./types";
 import type { QueryOptions, MutationOptions } from "@/QueryProvider";
 import { instance } from "@/instance";
+import { notificationsKeys } from "./keys";
 
 const DOMAIN = "/notifications";
+
+export { notificationsKeys };
 
 export const useNotificationList = (
   isNew?: boolean,
   options?: QueryOptions<NotificationListResponse>
 ) => {
   return useQuery({
-    queryKey: ["notification-list", isNew],
+    queryKey: notificationsKeys.notificationList(isNew),
     queryFn: async () => {
       const { data } = await instance.get<NotificationListResponse>(DOMAIN, {
         params: { is_new: isNew }
@@ -63,7 +66,7 @@ export const useNotificationTopicStatus = (
   options?: QueryOptions<NotificationTopicResponse>
 ) => {
   return useQuery({
-    queryKey: ["notification-topic-status"],
+    queryKey: notificationsKeys.notificationTopicStatus(),
     queryFn: async () => {
       const { data } = await instance.get<NotificationTopicResponse>(
         `${DOMAIN}/topic`

--- a/packages/api/src/notifications/keys.ts
+++ b/packages/api/src/notifications/keys.ts
@@ -1,0 +1,4 @@
+export const notificationsKeys = {
+  notificationList: (isNew?: boolean) => ["notification-list", isNew],
+  notificationTopicStatus: () => ["notification-topic-status"]
+} as const;

--- a/packages/api/src/recruitments/index.ts
+++ b/packages/api/src/recruitments/index.ts
@@ -24,8 +24,11 @@ import type {
 } from "./types";
 import type { QueryOptions, MutationOptions } from "@/QueryProvider";
 import { instance } from "@/instance";
+import { recruitmentsKeys } from "./keys";
 
 const DOMAIN = "/recruitments";
+
+export { recruitmentsKeys };
 
 export const useCreateRecruitment = (
   options?: MutationOptions<CreateRecruitmentRequest>
@@ -112,7 +115,7 @@ export const useRecruitmentList = (
   options?: QueryOptions<StudentRecruitmentListResponse>
 ) => {
   return useQuery({
-    queryKey: ["recruitment-list", params],
+    queryKey: recruitmentsKeys.recruitmentList(params),
     queryFn: async () => {
       const { data } = await instance.get<StudentRecruitmentListResponse>(
         `${DOMAIN}/student`,
@@ -129,7 +132,7 @@ export const useStudentRecruitmentCount = (
   options?: QueryOptions<StudentRecruitmentCountResponse>
 ) => {
   return useQuery({
-    queryKey: ["student-recruitment-count", params],
+    queryKey: recruitmentsKeys.studentRecruitmentCount(params),
     queryFn: async () => {
       const { data } = await instance.get<StudentRecruitmentCountResponse>(
         `${DOMAIN}/student/count`,
@@ -146,7 +149,7 @@ export const useRecruitmentCount = (
   options?: QueryOptions<RecruitmentCountResponse>
 ) => {
   return useQuery({
-    queryKey: ["recruitment-count", params],
+    queryKey: recruitmentsKeys.recruitmentCount(params),
     queryFn: async () => {
       const { data } = await instance.get<RecruitmentCountResponse>(
         `${DOMAIN}/count`,
@@ -165,7 +168,7 @@ export const useRecruitmentDetail = (
   options?: QueryOptions<RecruitmentDetailResponse>
 ) => {
   return useQuery({
-    queryKey: ["recruitment-detail", recruitmentId],
+    queryKey: recruitmentsKeys.recruitmentDetail(recruitmentId),
     queryFn: async () => {
       const { data } = await instance.get<RecruitmentDetailResponse>(
         `${DOMAIN}/${recruitmentId}`
@@ -181,7 +184,7 @@ export const useTeacherRecruitmentList = (
   options?: QueryOptions<TeacherRecruitmentListResponse>
 ) => {
   return useQuery({
-    queryKey: ["teacher-recruitment-list", params],
+    queryKey: recruitmentsKeys.teacherRecruitmentList(params),
     queryFn: async () => {
       const { data } = await instance.get<TeacherRecruitmentListResponse>(
         `${DOMAIN}/teacher`,
@@ -198,7 +201,7 @@ export const useTeacherRecruitmentCount = (
   options?: QueryOptions<TeacherRecruitmentCountResponse>
 ) => {
   return useQuery({
-    queryKey: ["teacher-recruitment-count", params],
+    queryKey: recruitmentsKeys.teacherRecruitmentCount(params),
     queryFn: async () => {
       const { data } = await instance.get<TeacherRecruitmentCountResponse>(
         `${DOMAIN}/teacher/count`,
@@ -214,7 +217,7 @@ export const useTeacherRecruitmentListNoPage = (
   params?: TeacherRecruitmentNoPageQueryParams
 ) => {
   return useQuery({
-    queryKey: ["teacher-recruitment-list-no-page", params],
+    queryKey: recruitmentsKeys.teacherRecruitmentListNoPage(params),
     queryFn: async () => {
       const { data } = await instance.get<TeacherRecruitmentListResponse>(
         `${DOMAIN}/teacher/no-page`,
@@ -229,7 +232,7 @@ export const useMyRecruitments = (
   options?: QueryOptions<MyRecruitmentsResponse>
 ) => {
   return useQuery({
-    queryKey: ["my-recruitments"],
+    queryKey: recruitmentsKeys.myRecruitments(),
     queryFn: async () => {
       const { data } = await instance.get<MyRecruitmentsResponse>(
         `${DOMAIN}/my`
@@ -244,7 +247,7 @@ export const useMyRecentRecruitment = (
   options?: QueryOptions<MyRecentRecruitmentResponse>
 ) => {
   return useQuery({
-    queryKey: ["my-recent-recruitment"],
+    queryKey: recruitmentsKeys.myRecentRecruitment(),
     queryFn: async () => {
       const { data } = await instance.get<MyRecentRecruitmentResponse>(
         `${DOMAIN}/my/recent`
@@ -259,7 +262,7 @@ export const useRecruitmentFileDownload = (
   options?: QueryOptions<RecruitmentFileResponse>
 ) => {
   return useQuery({
-    queryKey: ["recruitment-file"],
+    queryKey: recruitmentsKeys.recruitmentFileDownload(),
     queryFn: async () => {
       const { data } = await instance.get<RecruitmentFileResponse>(
         `${DOMAIN}/file`,
@@ -277,7 +280,7 @@ export const useRecruitmentExists = (
   options?: QueryOptions<RecruitmentExistsResponse>
 ) => {
   return useQuery({
-    queryKey: ["recruitment-exists"],
+    queryKey: recruitmentsKeys.recruitmentExists(),
     queryFn: async () => {
       const { data } = await instance.get<RecruitmentExistsResponse>(
         `${DOMAIN}/exists`
@@ -292,7 +295,7 @@ export const useTeacherManualRecruitmentList = (
   options?: QueryOptions<TeacherManualRecruitmentListResponse>
 ) => {
   return useQuery({
-    queryKey: ["teacher-manual-recruitment-list"],
+    queryKey: recruitmentsKeys.teacherManualRecruitmentList(),
     queryFn: async () => {
       const { data } = await instance.get<TeacherManualRecruitmentListResponse>(
         `${DOMAIN}/teacher/manual`

--- a/packages/api/src/recruitments/keys.ts
+++ b/packages/api/src/recruitments/keys.ts
@@ -1,0 +1,41 @@
+import type {
+  StudentRecruitmentListQueryParams,
+  RecruitmentCountQueryParams,
+  TeacherRecruitmentListQueryParams,
+  TeacherRecruitmentNoPageQueryParams,
+  TeacherRecruitmentCountQueryParams
+} from "./types";
+
+export const recruitmentsKeys = {
+  recruitmentList: (params?: StudentRecruitmentListQueryParams) => [
+    "recruitment-list",
+    params
+  ],
+  studentRecruitmentCount: (
+    params?: Omit<StudentRecruitmentListQueryParams, "page">
+  ) => ["student-recruitment-count", params],
+  recruitmentCount: (params?: RecruitmentCountQueryParams) => [
+    "recruitment-count",
+    params
+  ],
+  recruitmentDetail: (recruitmentId: number) => [
+    "recruitment-detail",
+    recruitmentId
+  ],
+  teacherRecruitmentList: (params?: TeacherRecruitmentListQueryParams) => [
+    "teacher-recruitment-list",
+    params
+  ],
+  teacherRecruitmentCount: (params?: TeacherRecruitmentCountQueryParams) => [
+    "teacher-recruitment-count",
+    params
+  ],
+  teacherRecruitmentListNoPage: (
+    params?: TeacherRecruitmentNoPageQueryParams
+  ) => ["teacher-recruitment-list-no-page", params],
+  myRecruitments: () => ["my-recruitments"],
+  myRecentRecruitment: () => ["my-recent-recruitment"],
+  recruitmentFileDownload: () => ["recruitment-file"],
+  recruitmentExists: () => ["recruitment-exists"],
+  teacherManualRecruitmentList: () => ["teacher-manual-recruitment-list"]
+} as const;

--- a/packages/api/src/reviews/index.ts
+++ b/packages/api/src/reviews/index.ts
@@ -11,15 +11,18 @@ import type {
 } from "./types";
 import type { QueryOptions, MutationOptions } from "@/QueryProvider";
 import { instance } from "@/instance";
+import { reviewsKeys } from "./keys";
 
 const DOMAIN = "/reviews";
+
+export { reviewsKeys };
 
 export const useReviewDetail = (
   reviewId: string,
   options?: QueryOptions<ReviewDetailResponse>
 ) => {
   return useQuery({
-    queryKey: ["review-detail", reviewId],
+    queryKey: reviewsKeys.reviewDetail(reviewId),
     queryFn: async () => {
       const { data } = await instance.get<ReviewDetailResponse>(
         `${DOMAIN}/${reviewId}`
@@ -45,7 +48,7 @@ export const useReviewQuestions = (
   options?: QueryOptions<ReviewQuestionsResponse>
 ) => {
   return useQuery({
-    queryKey: ["review-questions"],
+    queryKey: reviewsKeys.reviewQuestions(),
     queryFn: async () => {
       const { data } = await instance.get<ReviewQuestionsResponse>(
         `${DOMAIN}/questions`
@@ -72,7 +75,7 @@ export const useReviewList = (
   options?: QueryOptions<ReviewListResponse>
 ) => {
   return useQuery({
-    queryKey: ["review-list", params],
+    queryKey: reviewsKeys.reviewList(params),
     queryFn: async () => {
       const { data } = await instance.get<ReviewListResponse>(DOMAIN, {
         params
@@ -88,7 +91,7 @@ export const useReviewCount = (
   options?: QueryOptions<ReviewCountResponse>
 ) => {
   return useQuery({
-    queryKey: ["review-count", params],
+    queryKey: reviewsKeys.reviewCount(params),
     queryFn: async () => {
       const { data } = await instance.get<ReviewCountResponse>(
         `${DOMAIN}/count`,
@@ -102,7 +105,7 @@ export const useReviewCount = (
 
 export const useMyReviews = (options?: QueryOptions<MyReviewsResponse>) => {
   return useQuery({
-    queryKey: ["my-reviews"],
+    queryKey: reviewsKeys.myReviews(),
     queryFn: async () => {
       const { data } = await instance.get<MyReviewsResponse>(`${DOMAIN}/my`);
       return data;

--- a/packages/api/src/reviews/keys.ts
+++ b/packages/api/src/reviews/keys.ts
@@ -1,0 +1,9 @@
+import type { ReviewListQueryParams, ReviewCountQueryParams } from "./types";
+
+export const reviewsKeys = {
+  reviewDetail: (reviewId: string) => ["review-detail", reviewId],
+  reviewQuestions: () => ["review-questions"],
+  reviewList: (params?: ReviewListQueryParams) => ["review-list", params],
+  reviewCount: (params?: ReviewCountQueryParams) => ["review-count", params],
+  myReviews: () => ["my-reviews"]
+} as const;

--- a/packages/api/src/students/index.ts
+++ b/packages/api/src/students/index.ts
@@ -9,12 +9,15 @@ import type {
 } from "./types";
 import type { QueryOptions, MutationOptions } from "@/QueryProvider";
 import { instance } from "@/instance";
+import { studentsKeys } from "./keys";
 
 const DOMAIN = "/students";
 
+export { studentsKeys };
+
 export const useStudentMy = (options?: QueryOptions<StudentMyResponse>) => {
   return useQuery({
-    queryKey: ["student-my"],
+    queryKey: studentsKeys.studentMy(),
     queryFn: async () => {
       const { data } = await instance.get<StudentMyResponse>(`${DOMAIN}/my`);
       return data;
@@ -29,7 +32,7 @@ export const useStudentExists = (
   options?: QueryOptions<boolean>
 ) => {
   return useQuery({
-    queryKey: ["student-exists", gcn, name],
+    queryKey: studentsKeys.studentExists(gcn, name),
     queryFn: async () => {
       try {
         await instance.get(`${DOMAIN}/exists`, { params: { gcn, name } });

--- a/packages/api/src/students/keys.ts
+++ b/packages/api/src/students/keys.ts
@@ -1,0 +1,4 @@
+export const studentsKeys = {
+  studentMy: () => ["student-my"],
+  studentExists: (gcn?: string, name?: string) => ["student-exists", gcn, name]
+} as const;

--- a/packages/api/src/winter-intern/index.ts
+++ b/packages/api/src/winter-intern/index.ts
@@ -2,8 +2,11 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import type { WinterInternStatusResponse } from "./types";
 import type { QueryOptions, MutationOptions } from "@/QueryProvider";
 import { instance } from "@/instance";
+import { winterInternKeys } from "./keys";
 
 const DOMAIN = "/winter-intern";
+
+export { winterInternKeys };
 
 export const useToggleWinterIntern = (options?: MutationOptions<void>) => {
   return useMutation({
@@ -16,7 +19,7 @@ export const useToggleWinterIntern = (options?: MutationOptions<void>) => {
 
 export const useWinterInternStatus = (options?: QueryOptions<boolean>) => {
   return useQuery({
-    queryKey: ["winter-intern-status"],
+    queryKey: winterInternKeys.winterInternStatus(),
     queryFn: async () => {
       const { data } = await instance.get<WinterInternStatusResponse>(DOMAIN);
       return data.winter_intern;

--- a/packages/api/src/winter-intern/keys.ts
+++ b/packages/api/src/winter-intern/keys.ts
@@ -1,0 +1,3 @@
+export const winterInternKeys = {
+  winterInternStatus: () => ["winter-intern-status"]
+} as const;

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -2,11 +2,13 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
+    "rootDir": "src",
     "lib": ["es2020", "dom"],
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"]
     },
+    "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "dist"
   },

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "composite": true,
     "lib": ["es2020", "dom"],
     "types": ["vite/client"],
     "paths": {

--- a/packages/api/vite.config.ts
+++ b/packages/api/vite.config.ts
@@ -1,16 +1,13 @@
 import { defineConfig } from "vite";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 const FILE_NAME = fileURLToPath(import.meta.url);
 const DIR_NAME = dirname(FILE_NAME);
 
 export default defineConfig({
-  resolve: {
-    alias: {
-      "@": resolve(DIR_NAME, "src")
-    }
-  },
+  plugins: [tsconfigPaths()],
   build: {
     lib: {
       entry: resolve(DIR_NAME, "src/index.ts"),

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -6,7 +6,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/src/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/design-system/src/components/compound/ApplicationState/ApplicationState.test.tsx
+++ b/packages/design-system/src/components/compound/ApplicationState/ApplicationState.test.tsx
@@ -1,7 +1,7 @@
 import { screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { ApplicationState } from "./ApplicationState";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 import { lightTheme } from "@/themes";
 
 describe("ApplicationState", () => {

--- a/packages/design-system/src/components/compound/Bookmark/Bookmark.test.tsx
+++ b/packages/design-system/src/components/compound/Bookmark/Bookmark.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { Bookmark } from "./Bookmark";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("Bookmark", () => {
   it("renders correctly", () => {

--- a/packages/design-system/src/components/compound/Calendar/Calendar.test.tsx
+++ b/packages/design-system/src/components/compound/Calendar/Calendar.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { Calendar } from "./Calendar";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("Calendar", () => {
   it("renders with the correct month and year", () => {

--- a/packages/design-system/src/components/compound/Checkbox/Checkbox.test.tsx
+++ b/packages/design-system/src/components/compound/Checkbox/Checkbox.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { expect, describe, it, vi } from "vitest";
 import { Checkbox } from "./Checkbox";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("Checkbox", () => {
   it("renders correctly with default props", () => {

--- a/packages/design-system/src/components/compound/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/packages/design-system/src/components/compound/CheckboxGroup/CheckboxGroup.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { expect, describe, it, vi } from "vitest";
 import { CheckboxGroup } from "./CheckboxGroup";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("CheckboxGroup", () => {
   const mockOptions = [

--- a/packages/design-system/src/components/compound/CompanyCard/CompanyCard.test.tsx
+++ b/packages/design-system/src/components/compound/CompanyCard/CompanyCard.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { CompanyCard } from "./CompanyCard";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("CompanyCard", () => {
   const defaultProps = {

--- a/packages/design-system/src/components/compound/CompanyTypeChip/CompanyTypeChip.test.tsx
+++ b/packages/design-system/src/components/compound/CompanyTypeChip/CompanyTypeChip.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { CompanyTypeChip } from "./CompanyTypeChip";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("CompanyTypeClip", () => {
   it("renders correctly with participation type", () => {

--- a/packages/design-system/src/components/compound/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/compound/Dropdown/Dropdown.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 import { Dropdown } from "./Dropdown";
 
 const options = [

--- a/packages/design-system/src/components/compound/FileDownload/FileDownload.test.tsx
+++ b/packages/design-system/src/components/compound/FileDownload/FileDownload.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { expect, describe, it, vi } from "vitest";
 import { FileDownload } from "./FileDownload";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("FileDownload", () => {
   it("renders correctly with a label", () => {

--- a/packages/design-system/src/components/compound/Input/Input.test.tsx
+++ b/packages/design-system/src/components/compound/Input/Input.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 import { Input } from "./Input";
 
 describe("Input", () => {

--- a/packages/design-system/src/components/compound/Modal/Modal.test.tsx
+++ b/packages/design-system/src/components/compound/Modal/Modal.test.tsx
@@ -1,7 +1,7 @@
 import { screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Modal } from "./Modal";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("Modal", () => {
   const onConfirm = vi.fn();

--- a/packages/design-system/src/components/compound/NotificationItem/NotificationItem.test.tsx
+++ b/packages/design-system/src/components/compound/NotificationItem/NotificationItem.test.tsx
@@ -1,7 +1,7 @@
 import { screen, fireEvent } from "@testing-library/react";
 import { expect, describe, it, vi } from "vitest";
 import { NotificationItem } from "./NotificationItem";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("NotificationItem", () => {
   it("renders correctly with default props", () => {

--- a/packages/design-system/src/components/compound/Pagination/Pagination.test.tsx
+++ b/packages/design-system/src/components/compound/Pagination/Pagination.test.tsx
@@ -1,7 +1,7 @@
 import { screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { Pagination } from "./Pagination";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 import { lightTheme } from "@/themes";
 
 describe("Pagination", () => {

--- a/packages/design-system/src/components/compound/Radio/Radio.test.tsx
+++ b/packages/design-system/src/components/compound/Radio/Radio.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { expect, describe, it, vi } from "vitest";
 import { Radio } from "./Radio";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("Radio", () => {
   it("renders correctly with default props", () => {

--- a/packages/design-system/src/components/compound/RadioGroup/RadioGroup.test.tsx
+++ b/packages/design-system/src/components/compound/RadioGroup/RadioGroup.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { expect, describe, it, vi } from "vitest";
 import { RadioGroup } from "./RadioGroup";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("RadioGroup", () => {
   const mockOptions = [

--- a/packages/design-system/src/components/compound/RecrutementCard/RecrutementCard.test.tsx
+++ b/packages/design-system/src/components/compound/RecrutementCard/RecrutementCard.test.tsx
@@ -1,7 +1,7 @@
 import { screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { RecrutementCard } from "./RecrutementCard";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("RecrutementCard", () => {
   const defaultProps = {

--- a/packages/design-system/src/components/compound/Search/Search.test.tsx
+++ b/packages/design-system/src/components/compound/Search/Search.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 import { Search } from "./Search";
 
 describe("Search", () => {

--- a/packages/design-system/src/components/compound/Switch/Switch.test.tsx
+++ b/packages/design-system/src/components/compound/Switch/Switch.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { expect, describe, it, vi } from "vitest";
 import { Switch } from "./Switch";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 import { ThemeProvider } from "@emotion/react";
 import { darkTheme } from "@/themes";
 

--- a/packages/design-system/src/components/compound/Toast/Toast.test.tsx
+++ b/packages/design-system/src/components/compound/Toast/Toast.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { screen } from "@testing-library/react";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 import { Toast } from "./Toast";
 
 describe("Toast", () => {

--- a/packages/design-system/src/components/core/Button/Button.test.tsx
+++ b/packages/design-system/src/components/core/Button/Button.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { Button } from "./Button";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("Button", () => {
   it("renders correctly with children", () => {

--- a/packages/design-system/src/components/core/Text/Text.test.tsx
+++ b/packages/design-system/src/components/core/Text/Text.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/react";
 import { expect, describe, it } from "vitest";
 import { Text } from "./Text";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 
 describe("Text", () => {
   it("renders children correctly", () => {

--- a/packages/design-system/src/components/primitive/Box/Box.test.tsx
+++ b/packages/design-system/src/components/primitive/Box/Box.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/react";
-import { renderWithTheme } from "@/utils";
+import { renderWithTheme } from "@/utils/render";
 import { expect, describe, it } from "vitest";
 import { Box } from "./Box";
 import type { Props } from "./Box.types";

--- a/packages/design-system/src/utils/index.ts
+++ b/packages/design-system/src/utils/index.ts
@@ -1,3 +1,2 @@
 export * from "./parse";
-export * from "./render";
 export * from "./type";

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -4,7 +4,6 @@
     "baseUrl": ".",
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
-    "composite": true,
     "lib": ["es2020", "dom"],
     "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
     "paths": {

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -20,7 +20,9 @@ export default defineConfig({
       exclude: [
         "src/setupTests.ts",
         ".storybook/*",
+        "**/*.stories.ts",
         "**/*.stories.tsx",
+        "**/*.test.ts",
         "**/*.test.tsx"
       ]
     })

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -3,8 +3,14 @@
   "version": "0.0.0",
   "main": "dist/index.js",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && tsc -b --force",
     "lint": "eslint .",
     "type-check": "tsc --noEmit"
   },

--- a/packages/sentry/tsconfig.json
+++ b/packages/sentry/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "composite": true,
     "lib": ["es2020", "dom"],
     "types": ["vite/client"],
     "paths": {

--- a/packages/sentry/tsconfig.json
+++ b/packages/sentry/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
+    "rootDir": "src",
     "lib": ["es2020", "dom"],
     "types": ["vite/client"],
     "paths": {
@@ -9,6 +10,7 @@
     },
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
+    "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "dist"
   },

--- a/packages/sentry/vite.config.ts
+++ b/packages/sentry/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import react from "@vitejs/plugin-react";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 const FILE_NAME = fileURLToPath(import.meta.url);
 const DIR_NAME = dirname(FILE_NAME);
@@ -10,13 +11,9 @@ export default defineConfig({
   plugins: [
     react({
       jsxImportSource: "@emotion/react"
-    })
+    }),
+    tsconfigPaths()
   ],
-  resolve: {
-    alias: {
-      "@": resolve(DIR_NAME, "src")
-    }
-  },
   build: {
     lib: {
       entry: resolve(DIR_NAME, "src/index.ts"),

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -7,6 +7,16 @@
     "types": [
       "node",
       "vite/client"
-    ]
-  }
+    ],
+    "paths": {
+      "@jobis/api": ["./packages/api/src/index.ts"],
+      "@jobis/design-system": ["./packages/design-system/src/index.ts"],
+      "@jobis/sentry": ["./packages/sentry/src/index.ts"]
+    }
+  },
+  "references": [
+    { "path": "./packages/api" },
+    { "path": "./packages/design-system" },
+    { "path": "./packages/sentry" }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,19 @@
   "extends": "./tsconfig.base.json",
   "compileOnSave": false,
   "files": [],
-  "references": [
-    {
-      "path": "./apps/admin"
+  "compilerOptions": {
+    "paths": {
+      "@jobis/api": ["./packages/api/src/index.ts"],
+      "@jobis/design-system": ["./packages/design-system/src/index.ts"],
+      "@jobis/sentry": ["./packages/sentry/src/index.ts"]
     }
+  },
+  "references": [
+    { "path": "./packages/api" },
+    { "path": "./packages/design-system" },
+    { "path": "./packages/sentry" },
+    { "path": "./apps/admin" },
+    { "path": "./apps/company" },
+    { "path": "./apps/student" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2933,13 +2933,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jobis/admin@workspace:apps/admin"
   dependencies:
+    "@jobis/api": "workspace:*"
+    "@jobis/design-system": "workspace:*"
+    "@jobis/sentry": "workspace:*"
     "@types/node": "npm:^24.2.1"
     typescript: "npm:5.8.3"
     vite: "npm:5.3.1"
   languageName: unknown
   linkType: soft
 
-"@jobis/api@workspace:packages/api":
+"@jobis/api@workspace:*, @jobis/api@workspace:packages/api":
   version: 0.0.0-use.local
   resolution: "@jobis/api@workspace:packages/api"
   dependencies:
@@ -2960,13 +2963,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jobis/company@workspace:apps/company"
   dependencies:
+    "@jobis/api": "workspace:*"
+    "@jobis/design-system": "workspace:*"
+    "@jobis/sentry": "workspace:*"
     "@types/node": "npm:^24.2.1"
     typescript: "npm:5.8.3"
     vite: "npm:5.3.1"
   languageName: unknown
   linkType: soft
 
-"@jobis/design-system@workspace:packages/design-system":
+"@jobis/design-system@workspace:*, @jobis/design-system@workspace:packages/design-system":
   version: 0.0.0-use.local
   resolution: "@jobis/design-system@workspace:packages/design-system"
   dependencies:
@@ -3007,7 +3013,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jobis/sentry@workspace:packages/sentry":
+"@jobis/sentry@workspace:*, @jobis/sentry@workspace:packages/sentry":
   version: 0.0.0-use.local
   resolution: "@jobis/sentry@workspace:packages/sentry"
   dependencies:
@@ -3030,6 +3036,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jobis/student@workspace:apps/student"
   dependencies:
+    "@jobis/api": "workspace:*"
+    "@jobis/design-system": "workspace:*"
+    "@jobis/sentry": "workspace:*"
     "@types/node": "npm:^24.2.1"
     typescript: "npm:5.8.3"
     vite: "npm:5.3.1"


### PR DESCRIPTION
## 작업 내용 설명
- query key factory를 사용하도록 하고 QueryClient의 캐시 조작 메서드를 export

## 주요 변경 사항
- Query Key Factory 적용
- 캐시 조작 메서드 export

## 결과물
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 빌드 되나요? (`yarn build`)
- [x] 콘솔에 에러 없나요? (`yarn dev`)
- [ ] 목표한 부분만 수정했나요? (사이드 이펙트 체크)

## 해결 이슈
- resolved #77 