### PR TITLE
#101/improve api

### DIFF
--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import * as ReactDOM from "react-dom/client";
 import App from "./App";
 import { JOBISDesignSystem } from "@jobis/design-system";
-import { QueryProvider, setConfig } from "@jobis/api";
+import { QueryProvider, config } from "@jobis/api";
 import { init } from "@jobis/sentry";
 
 const root = ReactDOM.createRoot(
@@ -18,11 +18,9 @@ if (SENTRY_DSN) {
   });
 }
 
-setConfig({
-  onTokenExpired: () => {
-    window.location.href = "/login";
-  }
-});
+config.onTokenExpired = () => {
+  window.location.href = "/login";
+};
 
 root.render(
   <StrictMode>

--- a/apps/admin/src/pages/application/loader.ts
+++ b/apps/admin/src/pages/application/loader.ts
@@ -7,7 +7,7 @@ import {
   LoaderData,
   type QueryParamParser
 } from "../../utils";
-import { applicationsKeys, query, type ApplicationStatus } from "@jobis/api";
+import { useTeacherApplications, type ApplicationStatus } from "@jobis/api";
 
 export interface ApplicationQuery {
   student_name?: string;
@@ -55,16 +55,14 @@ export async function applicationLoader({
 }: LoaderFunctionArgs): Promise<LoaderData<ApplicationQuery>> {
   const queryParams = parseQueryParams(request, applicationQueryParser);
 
-  query.prefetch(
-    applicationsKeys.teacherApplications(
-      queryParams.application_status,
-      queryParams.student_name,
-      queryParams.recruitment_id,
-      queryParams.winter_intern,
-      queryParams.page,
-      queryParams.year
-    )
-  );
+  await useTeacherApplications.prefetch({
+    application_status: queryParams.application_status,
+    student_name: queryParams.student_name,
+    recruitment_id: queryParams.recruitment_id,
+    winter_intern: queryParams.winter_intern,
+    page: queryParams.page,
+    year: queryParams.year
+  });
 
   return {
     params: queryParams

--- a/apps/admin/src/pages/application/page.tsx
+++ b/apps/admin/src/pages/application/page.tsx
@@ -229,14 +229,11 @@ export const Application = () => {
 
   const debouncedSearch = useDebounce(localSearch, 300);
 
-  const { data, isLoading } = useTeacherApplications(
-    applicationStatus,
-    getParam("student-name"),
-    undefined,
-    undefined,
-    undefined,
-    yearFilter
-  );
+  const { data, isLoading } = useTeacherApplications({
+    application_status: applicationStatus,
+    student_name: getParam("student-name"),
+    year: yearFilter
+  });
 
   const { mutate: updateApplicationStatus } = useUpdateApplicationStatus();
 
@@ -333,8 +330,8 @@ export const Application = () => {
     const currentSearchValue = getParam("student-name") ?? "";
     if (debouncedSearch !== currentSearchValue) {
       updateParams({
-        studentName: debouncedSearch || undefined,
-        page: undefined
+        "student-name": debouncedSearch || undefined,
+        "page": undefined
       });
     }
   }, [debouncedSearch, updateParams, getParam]);
@@ -370,7 +367,7 @@ export const Application = () => {
                 onToggle={isOpen => setOpenDropdown(isOpen ? "status" : null)}
                 value={applicationStatus}
                 onChange={val =>
-                  updateParams({ applicationStatus: val, page: undefined })
+                  updateParams({ "application-status": val, "page": undefined })
                 }
               />
               <Dropdown

--- a/apps/admin/src/pages/company/detail/loader.ts
+++ b/apps/admin/src/pages/company/detail/loader.ts
@@ -1,6 +1,6 @@
 import type { LoaderFunctionArgs } from "react-router-dom";
 import { redirect } from "react-router-dom";
-import { companiesKeys, query } from "@jobis/api";
+import { useCompanyDetail } from "@jobis/api";
 import { LoaderData } from "apps/admin/src/utils";
 
 export async function companyDetailLoader({
@@ -12,7 +12,7 @@ export async function companyDetailLoader({
     throw redirect("/company");
   }
 
-  query.prefetch(companiesKeys.companyDetail(id));
+  await useCompanyDetail.prefetch(id);
 
   return { params: id };
 }

--- a/apps/admin/src/pages/company/edit/loader.ts
+++ b/apps/admin/src/pages/company/edit/loader.ts
@@ -1,6 +1,6 @@
 import type { LoaderFunctionArgs } from "react-router-dom";
 import { redirect } from "react-router-dom";
-import { companiesKeys, query } from "@jobis/api";
+import { useCompanyDetail } from "@jobis/api";
 import { LoaderData } from "apps/admin/src/utils";
 
 export async function companyEditLoader({
@@ -12,7 +12,7 @@ export async function companyEditLoader({
     throw redirect("/company");
   }
 
-  query.prefetch(companiesKeys.companyDetail(id));
+  await useCompanyDetail.prefetch(id);
 
   return { params: id };
 }

--- a/apps/admin/src/pages/company/loader.ts
+++ b/apps/admin/src/pages/company/loader.ts
@@ -7,7 +7,7 @@ import {
   LoaderData,
   type QueryParamParser
 } from "../../utils";
-import { type CompanyType, companiesKeys, query } from "@jobis/api";
+import { type CompanyType, useTeacherCompanyList } from "@jobis/api";
 
 export interface CompanyQuery {
   name?: string;
@@ -39,15 +39,13 @@ export async function companyLoader({
 }: LoaderFunctionArgs): Promise<LoaderData<CompanyQuery>> {
   const queryParams = parseQueryParams(request, companyQueryParser);
 
-  query.prefetch(
-    companiesKeys.teacherCompanyList(
-      queryParams.page,
-      queryParams.type,
-      queryParams.name,
-      queryParams.region,
-      queryParams.businessArea
-    )
-  );
+  await useTeacherCompanyList.prefetch({
+    page: queryParams.page,
+    type: queryParams.type,
+    name: queryParams.name,
+    region: queryParams.region,
+    business_area: queryParams.businessArea
+  });
 
   return {
     params: queryParams

--- a/apps/admin/src/pages/company/page.tsx
+++ b/apps/admin/src/pages/company/page.tsx
@@ -174,13 +174,13 @@ export const Company = () => {
     );
   };
 
-  const { data, isLoading } = useTeacherCompanyList(
-    currentPage,
-    companyType,
-    getParam("name"),
-    region,
-    businessArea ? parseInt(businessArea, 10) : undefined
-  );
+  const { data, isLoading } = useTeacherCompanyList({
+    page: currentPage,
+    type: companyType,
+    name: getParam("name"),
+    region: region,
+    business_area: businessArea ? parseInt(businessArea, 10) : undefined
+  });
 
   const { mutate: updateCompanyType } = useUpdateCompanyType();
   const { mutate: updateMou } = useUpdateMou();
@@ -266,7 +266,7 @@ export const Company = () => {
                 }
                 value={businessArea}
                 onChange={val =>
-                  updateParams({ businessArea: val, page: undefined })
+                  updateParams({ "business-area": val, "page": undefined })
                 }
               />
               <Search

--- a/apps/admin/src/pages/recruitment/loader.ts
+++ b/apps/admin/src/pages/recruitment/loader.ts
@@ -7,7 +7,7 @@ import {
   LoaderData,
   type QueryParamParser
 } from "../../utils";
-import { recruitmentsKeys, query, type RecruitmentStatus } from "@jobis/api";
+import { useTeacherRecruitmentList, type RecruitmentStatus } from "@jobis/api";
 
 export interface RecruitmentQuery {
   company_name?: string;
@@ -53,7 +53,7 @@ export async function recruitmentLoader({
 }: LoaderFunctionArgs): Promise<LoaderData<RecruitmentQuery>> {
   const queryParams = parseQueryParams(request, recruitmentQueryParser);
 
-  query.prefetch(recruitmentsKeys.teacherRecruitmentList(queryParams));
+  await useTeacherRecruitmentList.prefetch(queryParams);
 
   return {
     params: queryParams

--- a/apps/admin/src/pages/recruitment/page.tsx
+++ b/apps/admin/src/pages/recruitment/page.tsx
@@ -202,8 +202,8 @@ export const Recruitment = () => {
     const currentSearchValue = getParam("company-name") ?? "";
     if (debouncedSearch !== currentSearchValue) {
       updateParams({
-        company_name: debouncedSearch || undefined,
-        page: undefined
+        "company-name": debouncedSearch || undefined,
+        "page": undefined
       });
     }
   }, [debouncedSearch, updateParams, getParam]);

--- a/apps/admin/src/router.tsx
+++ b/apps/admin/src/router.tsx
@@ -1,6 +1,5 @@
 import { Header, Footer } from "@jobis/design-system";
-import { createBrowserRouter, redirect, Outlet } from "react-router-dom";
-import { reviewsKeys, query, noticesKeys, bannersKeys } from "@jobis/api";
+import { createBrowserRouter, Outlet } from "react-router-dom";
 import {
   Application,
   applicationLoader,
@@ -63,22 +62,10 @@ export const router: ReturnType<typeof createBrowserRouter> =
           children: [
             {
               index: true,
-              loader: ({ params }) => {
-                query.prefetch(reviewsKeys.reviewList(params));
-                return null;
-              },
               element: <div>학생 후기 목록</div>
             },
             {
               path: "detail/:reviewId",
-              loader: ({ params }) => {
-                const id = String(params.reviewId);
-                if (!params.reviewId) {
-                  throw redirect("/review");
-                }
-                query.prefetch(reviewsKeys.reviewDetail(id));
-                return null;
-              },
               element: <div>학생 후기 상세</div>
             }
           ]
@@ -93,35 +80,15 @@ export const router: ReturnType<typeof createBrowserRouter> =
           children: [
             {
               index: true,
-              loader: () => {
-                query.prefetch(noticesKeys.noticeList());
-                return null;
-              },
               element: <div>공지사항 목록</div>
             },
             { path: "write", element: <div>공지사항 등록</div> },
             {
               path: "detail/:noticeId",
-              loader: ({ params }) => {
-                const id = Number(params.noticeId);
-                if (!params.noticeId || Number.isNaN(id)) {
-                  throw redirect("/notice");
-                }
-                query.prefetch(noticesKeys.noticeDetail(id));
-                return null;
-              },
               element: <div>공지사항 상세</div>
             },
             {
               path: "detail/edit/:noticeId",
-              loader: ({ params }) => {
-                const id = Number(params.noticeId);
-                if (!params.noticeId || Number.isNaN(id)) {
-                  throw redirect("/notice");
-                }
-                query.prefetch(noticesKeys.noticeDetail(id));
-                return null;
-              },
               element: <div>공지사항 수정</div>
             }
           ]
@@ -131,14 +98,6 @@ export const router: ReturnType<typeof createBrowserRouter> =
           children: [
             {
               index: true,
-              loader: ({ request }) => {
-                const url = new URL(request.url);
-                const isOpenedParam = url.searchParams.get("isOpened");
-                const isOpened =
-                  isOpenedParam === null ? undefined : isOpenedParam === "true";
-                query.prefetch(bannersKeys.teacherBannerList(isOpened));
-                return null;
-              },
               element: <div>배너 목록</div>
             },
             { path: "write", element: <div>배너 등록</div> },

--- a/apps/company/src/main.tsx
+++ b/apps/company/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import * as ReactDOM from "react-dom/client";
 import App from "./App";
 import { JOBISDesignSystem } from "@jobis/design-system";
-import { QueryProvider, setConfig } from "@jobis/api";
+import { QueryProvider, config } from "@jobis/api";
 import { init } from "@jobis/sentry";
 
 const root = ReactDOM.createRoot(
@@ -18,11 +18,9 @@ if (SENTRY_DSN) {
   });
 }
 
-setConfig({
-  onTokenExpired: () => {
-    window.location.href = "/login";
-  }
-});
+config.onTokenExpired = () => {
+  window.location.href = "/login";
+};
 
 root.render(
   <StrictMode>

--- a/apps/company/src/router.tsx
+++ b/apps/company/src/router.tsx
@@ -1,6 +1,5 @@
 import { createBrowserRouter } from "react-router-dom";
 import { Header } from "@jobis/design-system";
-import { applicationsKeys, companiesKeys, query } from "@jobis/api";
 
 export const router: ReturnType<typeof createBrowserRouter> =
   createBrowserRouter([
@@ -28,18 +27,10 @@ export const router: ReturnType<typeof createBrowserRouter> =
             { index: true, element: <div>기업정보 등록</div> },
             {
               path: "detail",
-              loader: () => {
-                query.prefetch(companiesKeys.companyMy());
-                return null;
-              },
               element: <div>내 기업정보</div>
             },
             {
               path: "detail/edit",
-              loader: () => {
-                query.prefetch(companiesKeys.companyMy());
-                return null;
-              },
               element: <div>기업 정보 수정</div>
             }
           ]
@@ -47,10 +38,6 @@ export const router: ReturnType<typeof createBrowserRouter> =
 
         {
           path: "/application",
-          loader: () => {
-            query.prefetch(applicationsKeys.companyApplications());
-            return null;
-          },
           element: <div>지원자</div>
         }
       ]

--- a/apps/student/src/main.tsx
+++ b/apps/student/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import * as ReactDOM from "react-dom/client";
 import App from "./App";
 import { JOBISDesignSystem } from "@jobis/design-system";
-import { QueryProvider, setConfig } from "@jobis/api";
+import { QueryProvider, config } from "@jobis/api";
 import { init } from "@jobis/sentry";
 
 const root = ReactDOM.createRoot(
@@ -18,11 +18,9 @@ if (SENTRY_DSN) {
   });
 }
 
-setConfig({
-  onTokenExpired: () => {
-    window.location.href = "/login";
-  }
-});
+config.onTokenExpired = () => {
+  window.location.href = "/login";
+};
 
 root.render(
   <StrictMode>

--- a/apps/student/src/pages/company-list/loader.ts
+++ b/apps/student/src/pages/company-list/loader.ts
@@ -6,7 +6,7 @@ import {
   LoaderData,
   type QueryParamParser
 } from "../../utils";
-import { companiesKeys, query, ListSortType } from "@jobis/api";
+import { useCompanyStudentList, ListSortType } from "@jobis/api";
 
 export interface CompanyQuery {
   name?: string;
@@ -32,13 +32,11 @@ export async function companyLoader({
 }: LoaderFunctionArgs): Promise<LoaderData<CompanyQuery>> {
   const queryParams = parseQueryParams(request, companyQueryParser);
 
-  await query.prefetch(
-    companiesKeys.companyStudentList({
-      page: queryParams.page,
-      name: queryParams.name,
-      sort_type: queryParams.sort_type
-    })
-  );
+  await useCompanyStudentList.prefetch({
+    page: queryParams.page,
+    name: queryParams.name,
+    sort_type: queryParams.sort_type
+  });
 
   return {
     params: queryParams

--- a/apps/student/src/router.tsx
+++ b/apps/student/src/router.tsx
@@ -1,14 +1,6 @@
-import {
-  applicationsKeys,
-  companiesKeys,
-  noticesKeys,
-  query,
-  recruitmentsKeys,
-  reviewsKeys,
-  studentsKeys
-} from "@jobis/api";
 import { Header, Footer } from "@jobis/design-system";
-import { createBrowserRouter, redirect, Outlet } from "react-router-dom";
+import { createBrowserRouter, Outlet } from "react-router-dom";
+import { companyLoader } from "./pages/company-list/loader";
 import { CompanyList } from "./pages/company-list/page";
 import { RecruitmentList } from "./pages/recruitment-list";
 
@@ -35,32 +27,11 @@ export const router: ReturnType<typeof createBrowserRouter> =
           children: [
             {
               index: true,
-              loader: ({ request }) => {
-                const url = new URL(request.url);
-                const pageParam = url.searchParams.get("page");
-                const nameParam = url.searchParams.get("name");
-                const page = pageParam === null ? undefined : Number(pageParam);
-                const name = nameParam === null ? undefined : String(nameParam);
-                if (Number.isNaN(page)) {
-                  redirect("/");
-                }
-                query.prefetch(
-                  companiesKeys.companyStudentList({ page, name })
-                );
-                return null;
-              },
+              loader: companyLoader,
               element: <CompanyList />
             },
             {
               path: "detail/:companyId",
-              loader: ({ params }) => {
-                const id = Number(params.companyId);
-                if (!params.companyId || Number.isNaN(id)) {
-                  throw redirect("/company");
-                }
-                query.prefetch(companiesKeys.companyDetail(id));
-                return null;
-              },
               element: <div>기업 상세</div>
             }
           ]
@@ -70,22 +41,10 @@ export const router: ReturnType<typeof createBrowserRouter> =
           children: [
             {
               index: true,
-              loader: ({ params }) => {
-                query.prefetch(recruitmentsKeys.recruitmentList(params));
-                return null;
-              },
               element: <RecruitmentList />
             },
             {
               path: "detail/:recruitmentId",
-              loader: ({ params }) => {
-                const id = Number(params.recruitmentId);
-                if (!params.recruitmentId || Number.isNaN(id)) {
-                  throw redirect("/recruitment");
-                }
-                query.prefetch(recruitmentsKeys.recruitmentDetail(id));
-                return null;
-              },
               element: <div>모집의뢰서 상세</div>
             }
           ]
@@ -95,22 +54,10 @@ export const router: ReturnType<typeof createBrowserRouter> =
           children: [
             {
               index: true,
-              loader: () => {
-                query.prefetch(noticesKeys.noticeList());
-                return null;
-              },
               element: <div>공지사항 목록</div>
             },
             {
               path: "detail/:noticeId",
-              loader: ({ params }) => {
-                const id = Number(params.noticeId);
-                if (!params.noticeId || Number.isNaN(id)) {
-                  throw redirect("/notice");
-                }
-                query.prefetch(noticesKeys.noticeDetail(id));
-                return null;
-              },
               element: <div>공지사항 상세</div>
             }
           ]
@@ -120,23 +67,11 @@ export const router: ReturnType<typeof createBrowserRouter> =
           children: [
             {
               index: true,
-              loader: ({ params }) => {
-                query.prefetch(reviewsKeys.reviewList(params));
-                return null;
-              },
               element: <div>후기 목록</div>
             },
             { path: "write", element: <div>후기 작성</div> },
             {
               path: "detail/:reviewId",
-              loader: ({ params }) => {
-                const id = String(params.reviewId);
-                if (!params.reviewId) {
-                  throw redirect("/review");
-                }
-                query.prefetch(reviewsKeys.reviewDetail(id));
-                return null;
-              },
               element: <div>후기 상세</div>
             },
             { path: "expectations", element: <div>예상 면접 질문 작성</div> }
@@ -144,18 +79,10 @@ export const router: ReturnType<typeof createBrowserRouter> =
         },
         {
           path: "/mypage",
-          loader: () => {
-            query.prefetch(studentsKeys.studentMy());
-            return null;
-          },
           element: <div>마이페이지</div>
         },
         {
           path: "/jobrate",
-          loader: () => {
-            query.prefetch(applicationsKeys.employmentCount());
-            return null;
-          },
           element: <div>취업률 페이지</div>
         }
       ]

--- a/packages/api/src/QueryProvider.ts
+++ b/packages/api/src/QueryProvider.ts
@@ -1,11 +1,10 @@
 import { createElement, type ReactNode } from "react";
 import {
-  QueryClient,
   QueryClientProvider,
   type UseQueryOptions,
   type UseMutationOptions
 } from "@tanstack/react-query";
-import { config } from "./config";
+import { queryClient } from "./query-client";
 
 export type QueryOptions<T> = Omit<
   UseQueryOptions<T, number>,
@@ -17,33 +16,17 @@ export type MutationOptions<Request, Response = void> = Omit<
   "mutationFn"
 >;
 
-const client = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: config.staleTime,
-      gcTime: config.gcTime,
-      retry: 1
-    }
-  }
-});
-
 export const query = {
-  async prefetch(queryKey: unknown[]) {
-    const vaildQueryKey = queryKey.filter(key => key !== undefined);
-    await client.prefetchQuery({
-      queryKey: vaildQueryKey
-    });
-  },
   async invalidate(queryKey: unknown[]) {
-    const vaildQueryKey = queryKey.filter(key => key !== undefined);
-    await client.invalidateQueries({ queryKey: vaildQueryKey });
+    const validQueryKey = queryKey.filter(key => key !== undefined);
+    await queryClient.invalidateQueries({ queryKey: validQueryKey });
   },
   remove(queryKey: unknown[]) {
-    const vaildQueryKey = queryKey.filter(key => key !== undefined);
-    client.removeQueries({ queryKey: vaildQueryKey });
+    const validQueryKey = queryKey.filter(key => key !== undefined);
+    queryClient.removeQueries({ queryKey: validQueryKey });
   }
 } as const;
 
 export const QueryProvider = ({ children }: { children: ReactNode }) => {
-  return createElement(QueryClientProvider, { client }, children);
+  return createElement(QueryClientProvider, { client: queryClient }, children);
 };

--- a/packages/api/src/acceptances/index.ts
+++ b/packages/api/src/acceptances/index.ts
@@ -1,14 +1,15 @@
-import type {
+﻿import type {
   AcceptanceDetailResponse,
   UpdateFieldTrainRequest,
   UpdateContractDateRequest,
   CreateEmploymentRequest,
   DeleteAcceptanceRequest
 } from "./types";
-import { createQueryHook, createMutationHook } from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 import { acceptancesKeys } from "./keys";
 
 const DOMAIN = "/acceptances";
+const { createQueryHook, createMutationHook } = createDomainApi(DOMAIN);
 
 export { acceptancesKeys };
 
@@ -16,7 +17,7 @@ export const useAcceptanceDetail = createQueryHook<
   number,
   AcceptanceDetailResponse
 >({
-  domain: companyId => `${DOMAIN}/${companyId}`,
+  path: companyId => `/${companyId}`,
   queryKey: acceptancesKeys.acceptanceDetail
 });
 
@@ -24,7 +25,7 @@ export const useUpdateFieldTrain = createMutationHook<
   UpdateFieldTrainRequest,
   void
 >({
-  domain: `${DOMAIN}/field-train`,
+  path: "/field-train",
   method: "patch"
 });
 
@@ -32,7 +33,7 @@ export const useUpdateContractDate = createMutationHook<
   UpdateContractDateRequest,
   void
 >({
-  domain: `${DOMAIN}/contract-date`,
+  path: "/contract-date",
   method: "patch"
 });
 
@@ -40,7 +41,7 @@ export const useCreateEmployment = createMutationHook<
   CreateEmploymentRequest,
   void
 >({
-  domain: `${DOMAIN}/employment`,
+  path: "/employment",
   method: "post"
 });
 
@@ -48,6 +49,6 @@ export const useDeleteAcceptance = createMutationHook<
   DeleteAcceptanceRequest,
   void
 >({
-  domain: DOMAIN,
+  path: "/",
   method: "delete"
 });

--- a/packages/api/src/applications/index.ts
+++ b/packages/api/src/applications/index.ts
@@ -1,4 +1,4 @@
-import type {
+﻿import type {
   EmploymentCountResponse,
   PassResponse,
   CompanyApplicationResponse,
@@ -8,14 +8,12 @@ import type {
   RejectionResponse,
   EmploymentResponse
 } from "./types";
-import {
-  createQueryHook,
-  createMutationHook,
-  createIdMutationHook
-} from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 import { applicationsKeys } from "./keys";
 
 const DOMAIN = "/applications";
+const { createQueryHook, createMutationHook, createIdMutationHook } =
+  createDomainApi(DOMAIN);
 
 export { applicationsKeys };
 
@@ -23,12 +21,12 @@ export const useEmploymentCount = createQueryHook<
   void,
   EmploymentCountResponse
 >({
-  domain: `${DOMAIN}/employment/count`,
+  path: "/employment/count",
   queryKey: applicationsKeys.employmentCount
 });
 
 export const usePass = createQueryHook<number, PassResponse>({
-  domain: companyId => `${DOMAIN}/pass/${companyId}`,
+  path: companyId => `/pass/${companyId}`,
   queryKey: applicationsKeys.pass
 });
 
@@ -36,7 +34,7 @@ export const useCompanyApplications = createQueryHook<
   void,
   CompanyApplicationResponse
 >({
-  domain: `${DOMAIN}/company`,
+  path: "/company",
   queryKey: applicationsKeys.companyApplications
 });
 
@@ -44,71 +42,38 @@ export const useStudentApplications = createQueryHook<
   void,
   StudentApplicationResponse
 >({
-  domain: `${DOMAIN}/students`,
+  path: "/students",
   queryKey: applicationsKeys.studentApplications
 });
 
-export const useTeacherApplications = (
-  applicationStatus?: string,
-  studentName?: string,
-  recruitmentId?: number,
-  winterIntern?: boolean,
-  page?: number,
-  year?: string
-) => {
-  return createQueryHook<
-    {
-      application_status?: string;
-      student_name?: string;
-      recruitment_id?: number;
-      winter_intern?: boolean;
-      page?: number;
-      year?: string;
-    },
-    TeacherApplicationResponse
-  >({
-    domain: DOMAIN,
-    queryKey: () =>
-      applicationsKeys.teacherApplications(
-        applicationStatus,
-        studentName,
-        recruitmentId,
-        winterIntern,
-        page,
-        year
-      )
-  })({
-    application_status: applicationStatus,
-    student_name: studentName,
-    recruitment_id: recruitmentId,
-    winter_intern: winterIntern,
-    page,
-    year
-  });
-};
+export const useTeacherApplications = createQueryHook<
+  {
+    application_status?: string;
+    student_name?: string;
+    recruitment_id?: number;
+    winter_intern?: boolean;
+    page?: number;
+    year?: string;
+  },
+  TeacherApplicationResponse
+>({
+  path: "/",
+  queryKey: applicationsKeys.teacherApplications
+});
 
-export const useTeacherApplicationCount = (
-  applicationStatus?: string,
-  studentName?: string
-) => {
-  return createQueryHook<
-    {
-      application_status?: string;
-      student_name?: string;
-    },
-    TeacherApplicationCountResponse
-  >({
-    domain: `${DOMAIN}/teacher/count`,
-    queryKey: () =>
-      applicationsKeys.teacherApplicationCount(applicationStatus, studentName)
-  })({
-    application_status: applicationStatus,
-    student_name: studentName
-  });
-};
+export const useTeacherApplicationCount = createQueryHook<
+  {
+    application_status?: string;
+    student_name?: string;
+  },
+  TeacherApplicationCountResponse
+>({
+  path: "/teacher/count",
+  queryKey: applicationsKeys.teacherApplicationCount
+});
 
 export const useDeleteApplication = createIdMutationHook<void, void>({
-  domain: DOMAIN,
+  path: "/",
   method: "delete"
 });
 
@@ -116,7 +81,7 @@ export const useCreateApplication = createIdMutationHook<
   { url: string; type: string }[],
   void
 >({
-  domain: DOMAIN,
+  path: "/",
   method: "post"
 });
 
@@ -124,7 +89,7 @@ export const useUpdateApplicationStatus = createMutationHook<
   { applicationIds: number[]; status: string },
   void
 >({
-  domain: `${DOMAIN}/status`,
+  path: "/status",
   method: "patch"
 });
 
@@ -132,7 +97,7 @@ export const useUpdateTrainDate = createMutationHook<
   { applicationIds: number[]; startDate: string; endDate: string },
   void
 >({
-  domain: `${DOMAIN}/train-date`,
+  path: "/train-date",
   method: "patch"
 });
 
@@ -143,12 +108,12 @@ export const useRejectApplication = createIdMutationHook<
   },
   void
 >({
-  domain: `${DOMAIN}/rejection`,
+  path: "/rejection",
   method: "patch"
 });
 
 export const useRejection = createQueryHook<number, RejectionResponse>({
-  domain: applicationId => `${DOMAIN}/rejection/${applicationId}`,
+  path: applicationId => `/rejection/${applicationId}`,
   queryKey: applicationsKeys.rejection
 });
 
@@ -156,56 +121,35 @@ export const useReapply = createIdMutationHook<
   { url: string; type: string }[],
   void
 >({
-  domain: DOMAIN,
+  path: "/",
   method: "put"
 });
 
-export const useApplicationCount = (
-  applicationStatus?: string,
-  studentName?: string,
-  recruitmentId?: number,
-  winterIntern?: boolean,
-  year?: string
-) => {
-  return createQueryHook<
-    {
-      application_status?: string;
-      student_name?: string;
-      recruitment_id?: number;
-      winter_intern?: boolean;
-      year?: string;
-    },
-    { count: number }
-  >({
-    domain: `${DOMAIN}/count`,
-    queryKey: () =>
-      applicationsKeys.applicationCount(
-        applicationStatus,
-        studentName,
-        recruitmentId,
-        winterIntern,
-        year
-      )
-  })({
-    application_status: applicationStatus,
-    student_name: studentName,
-    recruitment_id: recruitmentId,
-    winter_intern: winterIntern,
-    year
-  });
-};
+export const useApplicationCount = createQueryHook<
+  {
+    application_status?: string;
+    student_name?: string;
+    recruitment_id?: number;
+    winter_intern?: boolean;
+    year?: string;
+  },
+  { count: number }
+>({
+  path: "/count",
+  queryKey: applicationsKeys.applicationCount
+});
 
 export const useDeleteApplications = createMutationHook<string, void>({
-  domain: DOMAIN,
+  path: "/",
   method: "delete"
 });
 
 export const useEmployment = createQueryHook<void, EmploymentResponse>({
-  domain: `${DOMAIN}/employment`,
+  path: "/employment",
   queryKey: applicationsKeys.employment
 });
 
 export const useTeacherApprove = createIdMutationHook<string[], void>({
-  domain: `${DOMAIN}/teacher`,
+  path: "/teacher",
   method: "post"
 });

--- a/packages/api/src/applications/keys.ts
+++ b/packages/api/src/applications/keys.ts
@@ -3,40 +3,25 @@ export const applicationsKeys = {
   pass: (companyId: number) => ["pass", companyId],
   companyApplications: () => ["company-applications"],
   studentApplications: () => ["student-applications"],
-  teacherApplications: (
-    applicationStatus?: string,
-    studentName?: string,
-    recruitmentId?: number,
-    winterIntern?: boolean,
-    page?: number,
-    year?: string
-  ) => [
-    "teacher-applications",
-    applicationStatus,
-    studentName,
-    recruitmentId,
-    winterIntern,
-    page,
-    year
-  ],
-  teacherApplicationCount: (
-    applicationStatus?: string,
-    studentName?: string
-  ) => ["teacher-application-count", applicationStatus, studentName],
+  teacherApplications: (params?: {
+    application_status?: string;
+    student_name?: string;
+    recruitment_id?: number;
+    winter_intern?: boolean;
+    page?: number;
+    year?: string;
+  }) => ["teacher-applications", params],
+  teacherApplicationCount: (params?: {
+    application_status?: string;
+    student_name?: string;
+  }) => ["teacher-application-count", params],
   rejection: (applicationId: number) => ["rejection", applicationId],
-  applicationCount: (
-    applicationStatus?: string,
-    studentName?: string,
-    recruitmentId?: number,
-    winterIntern?: boolean,
-    year?: string
-  ) => [
-    "application-count",
-    applicationStatus,
-    studentName,
-    recruitmentId,
-    winterIntern,
-    year
-  ],
+  applicationCount: (params?: {
+    application_status?: string;
+    student_name?: string;
+    recruitment_id?: number;
+    winter_intern?: boolean;
+    year?: string;
+  }) => ["application-count", params],
   employment: () => ["employment"]
 } as const;

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -1,13 +1,14 @@
 import { useMutation } from "@tanstack/react-query";
 import type { LoginRequest, LoginResponse } from "./types";
 import type { MutationOptions } from "@/QueryProvider";
-import { createMutationHook } from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 import { instance } from "@/instance";
 
 const DOMAIN = "/auth";
+const { createMutationHook } = createDomainApi(DOMAIN);
 
 export const useCompanyLogin = createMutationHook<LoginRequest, LoginResponse>({
-  domain: `${DOMAIN}/company`,
+  path: "/company",
   method: "post"
 });
 
@@ -26,6 +27,6 @@ export const useSendAuthCode = createMutationHook<
   { email: string; codeType: string },
   void
 >({
-  domain: `${DOMAIN}/code`,
+  path: "/code",
   method: "post"
 });

--- a/packages/api/src/banners/index.ts
+++ b/packages/api/src/banners/index.ts
@@ -1,35 +1,35 @@
-import type {
+﻿import type {
   CreateBannerRequest,
   BannerListResponse,
   TeacherBannerListResponse
 } from "./types";
-import { createQueryHook, createMutationHook } from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 import { bannersKeys } from "./keys";
 
 const DOMAIN = "/banners";
+const { createQueryHook, createMutationHook } = createDomainApi(DOMAIN);
 
 export { bannersKeys };
 
 export const useCreateBanner = createMutationHook<CreateBannerRequest, void>({
-  domain: DOMAIN,
+  path: "/",
   method: "post"
 });
 
 export const useDeleteBanner = createMutationHook<{ bannerId: number }, void>({
-  domain: DOMAIN,
+  path: "/",
   method: "delete"
 });
 
 export const useBannerList = createQueryHook<void, BannerListResponse>({
-  domain: DOMAIN,
+  path: "/",
   queryKey: bannersKeys.bannerList
 });
 
-export const useTeacherBannerList = (isOpened?: boolean) => {
-  return createQueryHook<{ is_opended?: boolean }, TeacherBannerListResponse>({
-    domain: `${DOMAIN}/teacher`,
-    queryKey: () => bannersKeys.teacherBannerList(isOpened)
-  })({
-    is_opended: isOpened
-  });
-};
+export const useTeacherBannerList = createQueryHook<
+  { is_opened?: boolean },
+  TeacherBannerListResponse
+>({
+  path: "/teacher",
+  queryKey: params => bannersKeys.teacherBannerList(params?.is_opened)
+});

--- a/packages/api/src/bookmarks/index.ts
+++ b/packages/api/src/bookmarks/index.ts
@@ -1,13 +1,14 @@
-import type { BookmarksResponse } from "./types";
-import { createQueryHook, createMutationHook } from "@/create-hook";
+﻿import type { BookmarksResponse } from "./types";
+import { createDomainApi } from "@/create-hook";
 import { bookmarksKeys } from "./keys";
 
 const DOMAIN = "/bookmarks";
+const { createQueryHook, createMutationHook } = createDomainApi(DOMAIN);
 
 export { bookmarksKeys };
 
 export const useBookmarks = createQueryHook<void, BookmarksResponse>({
-  domain: DOMAIN,
+  path: "/",
   queryKey: bookmarksKeys.bookmarks
 });
 
@@ -15,6 +16,6 @@ export const useToggleBookmark = createMutationHook<
   { recruitmentId: number },
   void
 >({
-  domain: DOMAIN,
+  path: "/",
   method: "patch"
 });

--- a/packages/api/src/codes/index.ts
+++ b/packages/api/src/codes/index.ts
@@ -1,37 +1,28 @@
-import type {
+﻿import type {
   CodeListResponse,
   CreateCodeRequest,
   CreateCodeResponse
 } from "./types";
-import { createQueryHook, createMutationHook } from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 import { codesKeys } from "./keys";
 
 const DOMAIN = "/codes";
+const { createQueryHook, createMutationHook } = createDomainApi(DOMAIN);
 
 export { codesKeys };
 
-export const useCodeList = (
-  type: string,
-  keyword?: string,
-  parentCode?: number
-) => {
-  return createQueryHook<
-    { type: string; keyword?: string; parent_code?: number },
-    CodeListResponse
-  >({
-    domain: DOMAIN,
-    queryKey: () => codesKeys.codeList(type, keyword, parentCode)
-  })({
-    type,
-    keyword,
-    parent_code: parentCode
-  });
-};
+export const useCodeList = createQueryHook<
+  { type: string; keyword?: string; parent_code?: number },
+  CodeListResponse
+>({
+  path: "/",
+  queryKey: codesKeys.codeList
+});
 
 export const useCreateCode = createMutationHook<
   CreateCodeRequest,
   CreateCodeResponse
 >({
-  domain: DOMAIN,
+  path: "/",
   method: "post"
 });

--- a/packages/api/src/codes/keys.ts
+++ b/packages/api/src/codes/keys.ts
@@ -1,8 +1,7 @@
 export const codesKeys = {
-  codeList: (type: string, keyword?: string, parentCode?: number) => [
-    "code-list",
-    type,
-    keyword,
-    parentCode
-  ]
+  codeList: (params: {
+    type: string;
+    keyword?: string;
+    parent_code?: number;
+  }) => ["code-list", params]
 } as const;

--- a/packages/api/src/companies/index.ts
+++ b/packages/api/src/companies/index.ts
@@ -1,4 +1,4 @@
-import type {
+﻿import type {
   CompanyStudentListResponse,
   CompanyStudentCountResponse,
   CompanyReviewListResponse,
@@ -18,31 +18,30 @@ import type {
   CreateTeacherCompanyRequest,
   CompanyStudentList
 } from "./types";
-import {
-  createQueryHook,
-  createMutationHook,
-  createIdMutationHook
-} from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 import { instance } from "@/instance";
 import { useQuery } from "@tanstack/react-query";
 import { companiesKeys } from "./keys";
 
 const DOMAIN = "/companies";
+const { createQueryHook, createMutationHook, createIdMutationHook } =
+  createDomainApi(DOMAIN);
 
 export { companiesKeys };
 
-export const useCompanyStudentList = (params?: CompanyStudentList) => {
-  return createQueryHook<CompanyStudentList, CompanyStudentListResponse>({
-    domain: `${DOMAIN}/student`,
-    queryKey: () => companiesKeys.companyStudentList(params)
-  })(params);
-};
+export const useCompanyStudentList = createQueryHook<
+  CompanyStudentList,
+  CompanyStudentListResponse
+>({
+  path: "/student",
+  queryKey: companiesKeys.companyStudentList
+});
 
 export const useCompanyStudentCount = createQueryHook<
   { name?: string },
   CompanyStudentCountResponse
 >({
-  domain: `${DOMAIN}/student/count`,
+  path: "/student/count",
   queryKey: companiesKeys.companyStudentCount
 });
 
@@ -50,17 +49,17 @@ export const useCompanyReviewList = createQueryHook<
   void,
   CompanyReviewListResponse
 >({
-  domain: `${DOMAIN}/review`,
+  path: "/review",
   queryKey: companiesKeys.companyReviewList
 });
 
 export const useCompanyDetail = createQueryHook<number, CompanyDetailResponse>({
-  domain: companyId => `${DOMAIN}/${companyId}`,
+  path: companyId => `/${companyId}`,
   queryKey: companiesKeys.companyDetail
 });
 
 export const useCompanyMy = createQueryHook<void, CompanyMyResponse>({
-  domain: `${DOMAIN}/my`,
+  path: "/my",
   queryKey: companiesKeys.companyMy
 });
 
@@ -68,7 +67,7 @@ export const useUpdateCompany = createIdMutationHook<
   UpdateCompanyRequest,
   void
 >({
-  domain: DOMAIN,
+  path: "/",
   method: "patch"
 });
 
@@ -76,155 +75,89 @@ export const useCreateCompany = createMutationHook<
   CreateCompanyRequest,
   CreateCompanyResponse
 >({
-  domain: DOMAIN,
+  path: "/",
   method: "post"
 });
 
 export const useCompanyExists = createQueryHook<string, CompanyExistsResponse>({
-  domain: businessNumber => `${DOMAIN}/exists/${businessNumber}`,
+  path: businessNumber => `/exists/${businessNumber}`,
   queryKey: companiesKeys.companyExists
 });
 
 export const useUpdateMou = createMutationHook<UpdateMouRequest, void>({
-  domain: `${DOMAIN}/mou`,
+  path: "/mou",
   method: "patch"
 });
 
-export const useTeacherCompanyList = (
-  page?: number,
-  type?: string,
-  name?: string,
-  region?: string,
-  businessArea?: number
-) => {
-  return createQueryHook<
-    {
-      page?: number;
-      type?: string;
-      name?: string;
-      region?: string;
-      business_area?: number;
-    },
-    TeacherCompanyListResponse
-  >({
-    domain: `${DOMAIN}/teacher`,
-    queryKey: () =>
-      companiesKeys.teacherCompanyList(page, type, name, region, businessArea)
-  })({
-    page,
-    type,
-    name,
-    region,
-    business_area: businessArea
-  });
-};
+export const useTeacherCompanyList = createQueryHook<
+  {
+    page?: number;
+    type?: string;
+    name?: string;
+    region?: string;
+    business_area?: number;
+  },
+  TeacherCompanyListResponse
+>({
+  path: "/teacher",
+  queryKey: companiesKeys.teacherCompanyList
+});
 
-export const useTeacherCompanyCount = (
-  page?: number,
-  type?: string,
-  name?: string,
-  region?: string,
-  businessArea?: number
-) => {
-  return createQueryHook<
-    {
-      page?: number;
-      type?: string;
-      name?: string;
-      region?: string;
-      business_area?: number;
-    },
-    TeacherCompanyCountResponse
-  >({
-    domain: `${DOMAIN}/teacher/count`,
-    queryKey: () =>
-      companiesKeys.teacherCompanyCount(page, type, name, region, businessArea)
-  })({
-    page,
-    type,
-    name,
-    region,
-    business_area: businessArea
-  });
-};
+export const useTeacherCompanyCount = createQueryHook<
+  {
+    page?: number;
+    type?: string;
+    name?: string;
+    region?: string;
+    business_area?: number;
+  },
+  TeacherCompanyCountResponse
+>({
+  path: "/teacher/count",
+  queryKey: companiesKeys.teacherCompanyCount
+});
 
-export const useEmploymentCompanyList = (
-  page?: number,
-  companyName?: string,
-  companyType?: string,
-  year?: number
-) => {
-  return createQueryHook<
-    {
-      page?: number;
-      company_name?: string;
-      company_type?: string;
-      year?: number;
-    },
-    EmploymentCompanyListResponse
-  >({
-    domain: `${DOMAIN}/employment`,
-    queryKey: () =>
-      companiesKeys.employmentCompanyList(page, companyName, companyType, year)
-  })({
-    page,
-    company_name: companyName,
-    company_type: companyType,
-    year
-  });
-};
+export const useEmploymentCompanyList = createQueryHook<
+  {
+    page?: number;
+    company_name?: string;
+    company_type?: string;
+    year?: number;
+  },
+  EmploymentCompanyListResponse
+>({
+  path: "/employment",
+  queryKey: companiesKeys.employmentCompanyList
+});
 
-export const useEmploymentCompanyCount = (
-  companyName?: string,
-  companyType?: string,
-  year?: number
-) => {
-  return createQueryHook<
-    { company_name?: string; company_type?: string; year?: number },
-    EmploymentCompanyCountResponse
-  >({
-    domain: `${DOMAIN}/employment/count`,
-    queryKey: () =>
-      companiesKeys.employmentCompanyCount(companyName, companyType, year)
-  })({
-    company_name: companyName,
-    company_type: companyType,
-    year
-  });
-};
+export const useEmploymentCompanyCount = createQueryHook<
+  { company_name?: string; company_type?: string; year?: number },
+  EmploymentCompanyCountResponse
+>({
+  path: "/employment/count",
+  queryKey: companiesKeys.employmentCompanyCount
+});
 
 export const useUpdateCompanyType = createMutationHook<
   UpdateCompanyTypeRequest,
   void
 >({
-  domain: `${DOMAIN}/type`,
+  path: "/type",
   method: "patch"
 });
 
-export const useCompanyCount = (
-  type?: string,
-  name?: string,
-  region?: string,
-  businessArea?: number
-) => {
-  return createQueryHook<
-    {
-      type?: string;
-      name?: string;
-      region?: string;
-      business_area?: number;
-    },
-    CompanyCountResponse
-  >({
-    domain: `${DOMAIN}/count`,
-    queryKey: () => companiesKeys.companyCount(type, name, region, businessArea)
-  })({
-    type,
-    name,
-    region,
-    business_area: businessArea
-  });
-};
+export const useCompanyCount = createQueryHook<
+  {
+    type?: string;
+    name?: string;
+    region?: string;
+    business_area?: number;
+  },
+  CompanyCountResponse
+>({
+  path: "/count",
+  queryKey: companiesKeys.companyCount
+});
 
 export const useCompanyFileDownload = () => {
   return useQuery({
@@ -242,6 +175,6 @@ export const useCreateTeacherCompany = createMutationHook<
   CreateTeacherCompanyRequest,
   void
 >({
-  domain: `${DOMAIN}/teacher`,
+  path: "/teacher",
   method: "post"
 });

--- a/packages/api/src/companies/keys.ts
+++ b/packages/api/src/companies/keys.ts
@@ -7,42 +7,42 @@ export const companiesKeys = {
   ],
   companyStudentCount: (params?: { name?: string }) => [
     "company-student-count",
-    params?.name
+    params
   ],
   companyReviewList: () => ["company-review-list"],
   companyDetail: (companyId: number) => ["company-detail", companyId],
   companyMy: () => ["company-my"],
   companyExists: (businessNumber: string) => ["company-exists", businessNumber],
-  teacherCompanyList: (
-    page?: number,
-    type?: string,
-    name?: string,
-    region?: string,
-    businessArea?: number
-  ) => ["teacher-company-list", page, type, name, region, businessArea],
-  teacherCompanyCount: (
-    page?: number,
-    type?: string,
-    name?: string,
-    region?: string,
-    businessArea?: number
-  ) => ["teacher-company-count", page, type, name, region, businessArea],
-  employmentCompanyList: (
-    page?: number,
-    companyName?: string,
-    companyType?: string,
-    year?: number
-  ) => ["employment-company-list", page, companyName, companyType, year],
-  employmentCompanyCount: (
-    companyName?: string,
-    companyType?: string,
-    year?: number
-  ) => ["employment-company-count", companyName, companyType, year],
-  companyCount: (
-    type?: string,
-    name?: string,
-    region?: string,
-    businessArea?: number
-  ) => ["company-count", type, name, region, businessArea],
+  teacherCompanyList: (params?: {
+    page?: number;
+    type?: string;
+    name?: string;
+    region?: string;
+    business_area?: number;
+  }) => ["teacher-company-list", params],
+  teacherCompanyCount: (params?: {
+    page?: number;
+    type?: string;
+    name?: string;
+    region?: string;
+    business_area?: number;
+  }) => ["teacher-company-count", params],
+  employmentCompanyList: (params?: {
+    page?: number;
+    company_name?: string;
+    company_type?: string;
+    year?: number;
+  }) => ["employment-company-list", params],
+  employmentCompanyCount: (params?: {
+    company_name?: string;
+    company_type?: string;
+    year?: number;
+  }) => ["employment-company-count", params],
+  companyCount: (params?: {
+    type?: string;
+    name?: string;
+    region?: string;
+    business_area?: number;
+  }) => ["company-count", params],
   companyFileDownload: () => ["company-file"]
 } as const;

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -1,16 +1,16 @@
 import type { AxiosError } from "axios";
 
 interface Config {
-  baseUrl: string;
-  timeout: number;
-  staleTime: number;
-  gcTime: number;
+  readonly baseUrl: string;
+  readonly timeout: number;
+  readonly staleTime: number;
+  readonly gcTime: number;
   onServerError?: (error: AxiosError) => void;
   onTimeout?: (error: AxiosError) => void;
   onTokenExpired?: () => void;
 }
 
-export const createConfig = (): Config => ({
+export const config: Config = {
   baseUrl: import.meta.env.BASE_URL!,
   timeout: 10000,
   staleTime: 60000,
@@ -21,10 +21,4 @@ export const createConfig = (): Config => ({
   onTimeout: error => {
     console.error("서버 응답이 지연되고 있습니다.", error);
   }
-});
-
-export const config = createConfig();
-
-export const setConfig = (overrides: Partial<Config>) => {
-  Object.assign(config, overrides);
 };

--- a/packages/api/src/create-hook.ts
+++ b/packages/api/src/create-hook.ts
@@ -1,84 +1,130 @@
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { instance } from "./instance";
 import type { QueryOptions, MutationOptions } from "./QueryProvider";
+import { queryClient } from "./query-client";
 
 type QueryKeyFactory<TParams> = (params: TParams) => unknown[];
 
 interface QueryHookConfig<TParams> {
-  domain: string | ((params: TParams) => string);
+  path: string | ((params: TParams) => string);
   queryKey: QueryKeyFactory<TParams>;
 }
 
 interface MutationHookConfig<TRequest> {
-  domain: string | ((request: TRequest) => string);
-  method?: "post" | "patch" | "delete" | "put";
+  path: string | ((request: TRequest) => string);
+  method: "post" | "patch" | "delete" | "put";
 }
 
-export const createQueryHook = <TParams, TResponse>({
-  domain,
-  queryKey
-}: QueryHookConfig<TParams>) => {
-  return (params?: TParams, options?: QueryOptions<TResponse>) => {
-    return useQuery({
+interface IdMutationHookConfig {
+  path: string;
+  method: "post" | "patch" | "delete" | "put";
+}
+
+type QueryHook<TParams, TResponse> = {
+  (
+    params?: TParams,
+    options?: QueryOptions<TResponse>
+  ): ReturnType<typeof useQuery<TResponse, number>>;
+  prefetch: (
+    params?: TParams,
+    options?: QueryOptions<TResponse>
+  ) => Promise<void>;
+};
+
+const resolvePath = <T>(
+  path: string | ((args: T) => string),
+  args?: T
+): string => {
+  if (path === "/") return "";
+  return typeof path === "function" ? path(args as T) : path;
+};
+
+export const createDomainApi = (domain: string) => {
+  const createQueryHook = <TParams, TResponse>({
+    path,
+    queryKey
+  }: QueryHookConfig<TParams>) => {
+    const buildQueryOptions = (
+      params?: TParams,
+      options?: QueryOptions<TResponse>
+    ) => ({
       queryKey: queryKey(params as TParams),
       queryFn: async () => {
-        const url =
-          typeof domain === "function" ? domain(params as TParams) : domain;
-        const { data } = await instance.get<TResponse>(url, {
-          params:
-            typeof params === "object" && params !== null ? params : undefined
-        });
+        const resolvedPath = resolvePath(path, params);
+        const { data } = await instance.get<TResponse>(
+          `${domain}${resolvedPath}`,
+          {
+            params:
+              typeof params === "object" && params !== null ? params : undefined
+          }
+        );
         return data;
       },
       ...options
     });
-  };
-};
 
-export const createMutationHook = <TRequest, TResponse = void>({
-  domain,
-  method = "post"
-}: MutationHookConfig<TRequest>) => {
-  return (options?: MutationOptions<TRequest, TResponse>) => {
-    return useMutation({
-      mutationFn: async (request: TRequest) => {
-        const url = typeof domain === "function" ? domain(request) : domain;
-        const { data } = await instance<TResponse>({
-          method,
-          url,
-          data: request
-        });
-        return data;
-      },
-      ...options
-    });
-  };
-};
+    const hook = ((params?: TParams, options?: QueryOptions<TResponse>) => {
+      return useQuery({
+        ...buildQueryOptions(params, options)
+      });
+    }) as QueryHook<TParams, TResponse>;
 
-/**
- * ID 를 인자로 받는 Mutation Hook 팩토리
- * domain 이 ID 를 포함하는 URL 을 동적으로 생성할 때 사용
- */
-export const createIdMutationHook = <TRequest, TResponse = void>({
-  domain,
-  method = "post"
-}: MutationHookConfig<TRequest>) => {
-  return (
-    id: number | string,
-    options?: MutationOptions<TRequest, TResponse>
-  ) => {
-    return useMutation({
-      mutationFn: async (request: TRequest) => {
-        const url =
-          typeof domain === "function" ? domain(request) : `${domain}/${id}`;
-        const { data } = await instance<TResponse>({
-          method,
-          url,
-          data: request
-        });
-        return data;
-      },
-      ...options
-    });
+    hook.prefetch = async (
+      params?: TParams,
+      options?: QueryOptions<TResponse>
+    ) => {
+      await queryClient.prefetchQuery(buildQueryOptions(params, options));
+    };
+
+    return hook;
+  };
+
+  const createMutationHook = <TRequest, TResponse = void>({
+    path,
+    method
+  }: MutationHookConfig<TRequest>) => {
+    return (options?: MutationOptions<TRequest, TResponse>) => {
+      return useMutation({
+        mutationFn: async (request: TRequest) => {
+          const resolvedPath = resolvePath(path, request);
+          const { data } = await instance<TResponse>({
+            method,
+            url: `${domain}${resolvedPath}`,
+            data: request
+          });
+          return data;
+        },
+        ...options
+      });
+    };
+  };
+
+  const createIdMutationHook = <TRequest, TResponse = void>({
+    path,
+    method
+  }: IdMutationHookConfig) => {
+    return (
+      id: number | string,
+      options?: MutationOptions<TRequest, TResponse>
+    ) => {
+      return useMutation({
+        mutationFn: async (request: TRequest) => {
+          const url = `${domain}${path}/${id}`;
+          const { data } = await instance<TResponse>({
+            method,
+            url,
+            data: request
+          });
+          return data;
+        },
+        ...options
+      });
+    };
+  };
+
+  return {
+    createQueryHook,
+    createMutationHook,
+    createIdMutationHook
   };
 };

--- a/packages/api/src/files/index.ts
+++ b/packages/api/src/files/index.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import type { MutationOptions } from "@/QueryProvider";
-import { config } from "..";
+import { config } from "@/config";
 import axios from "axios";
 
 export const getFile = async (url: string) => {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -8,7 +8,7 @@ export {
   removeCookie,
   getCookie
 } from "./instance";
-export { createQueryHook, createMutationHook } from "./create-hook";
+export { createDomainApi } from "./create-hook";
 
 export * from "./acceptances";
 export * from "./applications";

--- a/packages/api/src/notices/index.ts
+++ b/packages/api/src/notices/index.ts
@@ -1,41 +1,39 @@
-import type {
+﻿import type {
   CreateNoticeRequest,
   UpdateNoticeRequest,
   NoticeDetailResponse,
   NoticeListResponse
 } from "./types";
-import {
-  createQueryHook,
-  createMutationHook,
-  createIdMutationHook
-} from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 import { noticesKeys } from "./keys";
 
 const DOMAIN = "/notices";
+const { createQueryHook, createMutationHook, createIdMutationHook } =
+  createDomainApi(DOMAIN);
 
 export { noticesKeys };
 
 export const useCreateNotice = createMutationHook<CreateNoticeRequest, void>({
-  domain: DOMAIN,
+  path: "/",
   method: "post"
 });
 
 export const useUpdateNotice = createIdMutationHook<UpdateNoticeRequest, void>({
-  domain: DOMAIN,
+  path: "/",
   method: "patch"
 });
 
 export const useDeleteNotice = createIdMutationHook<void, void>({
-  domain: DOMAIN,
+  path: "/",
   method: "delete"
 });
 
 export const useNoticeDetail = createQueryHook<number, NoticeDetailResponse>({
-  domain: noticeId => `${DOMAIN}/${noticeId}`,
+  path: noticeId => `/${noticeId}`,
   queryKey: noticesKeys.noticeDetail
 });
 
 export const useNoticeList = createQueryHook<void, NoticeListResponse>({
-  domain: DOMAIN,
+  path: "/",
   queryKey: noticesKeys.noticeList
 });

--- a/packages/api/src/notifications/index.ts
+++ b/packages/api/src/notifications/index.ts
@@ -1,31 +1,31 @@
-import { useMutation } from "@tanstack/react-query";
+﻿import { useMutation } from "@tanstack/react-query";
 import type {
   NotificationListResponse,
   NotificationTopicResponse
 } from "./types";
 import type { MutationOptions } from "@/QueryProvider";
-import { createQueryHook, createMutationHook } from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 import { instance } from "@/instance";
 import { notificationsKeys } from "./keys";
 
 const DOMAIN = "/notifications";
+const { createQueryHook, createMutationHook } = createDomainApi(DOMAIN);
 
 export { notificationsKeys };
 
-export const useNotificationList = (isNew?: boolean) => {
-  return createQueryHook<{ is_new?: boolean }, NotificationListResponse>({
-    domain: DOMAIN,
-    queryKey: () => notificationsKeys.notificationList(isNew)
-  })({
-    is_new: isNew
-  });
-};
+export const useNotificationList = createQueryHook<
+  { is_new?: boolean },
+  NotificationListResponse
+>({
+  path: "/",
+  queryKey: params => notificationsKeys.notificationList(params?.is_new)
+});
 
 export const useReadNotification = createMutationHook<
   { notificationId: number },
   void
 >({
-  domain: DOMAIN,
+  path: "/",
   method: "patch"
 });
 
@@ -34,7 +34,7 @@ export const useToggleNotificationTopic = (
 ) => {
   return useMutation({
     mutationFn: async ({ topic }) => {
-      await instance.patch(`${DOMAIN}/topic`, {
+      await instance.patch(`${DOMAIN}/topic`, undefined, {
         params: { topic }
       });
     },
@@ -43,7 +43,7 @@ export const useToggleNotificationTopic = (
 };
 
 export const useToggleAllNotificationTopics = createMutationHook<void, void>({
-  domain: `${DOMAIN}/topics`,
+  path: "/topics",
   method: "patch"
 });
 
@@ -51,6 +51,6 @@ export const useNotificationTopicStatus = createQueryHook<
   void,
   NotificationTopicResponse
 >({
-  domain: `${DOMAIN}/topic`,
+  path: "/topic",
   queryKey: notificationsKeys.notificationTopicStatus
 });

--- a/packages/api/src/query-client.ts
+++ b/packages/api/src/query-client.ts
@@ -1,0 +1,12 @@
+import { QueryClient } from "@tanstack/react-query";
+import { config } from "./config";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: config.staleTime,
+      gcTime: config.gcTime,
+      retry: 1
+    }
+  }
+});

--- a/packages/api/src/recruitments/index.ts
+++ b/packages/api/src/recruitments/index.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+﻿import { useQuery } from "@tanstack/react-query";
 import type {
   CreateRecruitmentRequest,
   StudentRecruitmentListResponse,
@@ -22,15 +22,13 @@ import type {
   TeacherRecruitmentCountQueryParams,
   TeacherRecruitmentCountResponse
 } from "./types";
-import {
-  createQueryHook,
-  createMutationHook,
-  createIdMutationHook
-} from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 import { instance } from "@/instance";
 import { recruitmentsKeys } from "./keys";
 
 const DOMAIN = "/recruitments";
+const { createQueryHook, createMutationHook, createIdMutationHook } =
+  createDomainApi(DOMAIN);
 
 export { recruitmentsKeys };
 
@@ -38,7 +36,7 @@ export const useRecruitmentList = createQueryHook<
   StudentRecruitmentListQueryParams,
   StudentRecruitmentListResponse
 >({
-  domain: `${DOMAIN}/student`,
+  path: "/student",
   queryKey: recruitmentsKeys.recruitmentList
 });
 
@@ -46,7 +44,7 @@ export const useStudentRecruitmentCount = createQueryHook<
   Omit<StudentRecruitmentListQueryParams, "page">,
   StudentRecruitmentCountResponse
 >({
-  domain: `${DOMAIN}/student/count`,
+  path: "/student/count",
   queryKey: recruitmentsKeys.studentRecruitmentCount
 });
 
@@ -54,7 +52,7 @@ export const useRecruitmentCount = createQueryHook<
   RecruitmentCountQueryParams,
   RecruitmentCountResponse
 >({
-  domain: `${DOMAIN}/count`,
+  path: "/count",
   queryKey: recruitmentsKeys.recruitmentCount
 });
 
@@ -62,7 +60,7 @@ export const useRecruitmentDetail = createQueryHook<
   number,
   RecruitmentDetailResponse
 >({
-  domain: recruitmentId => `${DOMAIN}/${recruitmentId}`,
+  path: recruitmentId => `/${recruitmentId}`,
   queryKey: recruitmentsKeys.recruitmentDetail
 });
 
@@ -70,7 +68,7 @@ export const useTeacherRecruitmentList = createQueryHook<
   TeacherRecruitmentListQueryParams,
   TeacherRecruitmentListResponse
 >({
-  domain: `${DOMAIN}/teacher`,
+  path: "/teacher",
   queryKey: recruitmentsKeys.teacherRecruitmentList
 });
 
@@ -78,7 +76,7 @@ export const useTeacherRecruitmentCount = createQueryHook<
   TeacherRecruitmentCountQueryParams,
   TeacherRecruitmentCountResponse
 >({
-  domain: `${DOMAIN}/teacher/count`,
+  path: "/teacher/count",
   queryKey: recruitmentsKeys.teacherRecruitmentCount
 });
 
@@ -86,12 +84,12 @@ export const useTeacherRecruitmentListNoPage = createQueryHook<
   TeacherRecruitmentNoPageQueryParams,
   TeacherRecruitmentListResponse
 >({
-  domain: `${DOMAIN}/teacher/no-page`,
+  path: "/teacher/no-page",
   queryKey: recruitmentsKeys.teacherRecruitmentListNoPage
 });
 
 export const useMyRecruitments = createQueryHook<void, MyRecruitmentsResponse>({
-  domain: `${DOMAIN}/my`,
+  path: "/my",
   queryKey: recruitmentsKeys.myRecruitments
 });
 
@@ -99,7 +97,7 @@ export const useMyRecentRecruitment = createQueryHook<
   void,
   MyRecentRecruitmentResponse
 >({
-  domain: `${DOMAIN}/my/recent`,
+  path: "/my/recent",
   queryKey: recruitmentsKeys.myRecentRecruitment
 });
 
@@ -107,7 +105,7 @@ export const useRecruitmentExists = createQueryHook<
   void,
   RecruitmentExistsResponse
 >({
-  domain: `${DOMAIN}/exists`,
+  path: "/exists",
   queryKey: recruitmentsKeys.recruitmentExists
 });
 
@@ -115,7 +113,7 @@ export const useTeacherManualRecruitmentList = createQueryHook<
   void,
   TeacherManualRecruitmentListResponse
 >({
-  domain: `${DOMAIN}/teacher/manual`,
+  path: "/teacher/manual",
   queryKey: recruitmentsKeys.teacherManualRecruitmentList
 });
 
@@ -143,35 +141,35 @@ export const useCreateRecruitment = createMutationHook<
   CreateRecruitmentRequest,
   void
 >({
-  domain: DOMAIN,
+  path: "/",
   method: "post"
 });
 
 export const useUpdateRecruitment = (id: number) =>
   createMutationHook<UpdateRecruitmentRequest, void>({
-    domain: `${DOMAIN}/${id}`,
+    path: `/${id}`,
     method: "patch"
   });
 
 export const useDeleteRecruitment = createIdMutationHook<void, void>({
-  domain: DOMAIN,
+  path: "/",
   method: "delete"
 });
 
 export const useUpdateRecruitmentArea = (recruitAreaId: number) =>
   createMutationHook<UpdateRecruitmentAreaRequest, void>({
-    domain: `${DOMAIN}/area/${recruitAreaId}`,
+    path: `/area/${recruitAreaId}`,
     method: "patch"
   });
 
 export const useCreateRecruitmentArea = (recruitmentId: number) =>
   createMutationHook<CreateRecruitmentAreaRequest, void>({
-    domain: `${DOMAIN}/${recruitmentId}/area`,
+    path: `/${recruitmentId}/area`,
     method: "post"
   });
 
 export const useDeleteRecruitmentArea = createIdMutationHook<void, void>({
-  domain: `${DOMAIN}/area`,
+  path: "/area",
   method: "delete"
 });
 
@@ -179,6 +177,6 @@ export const useUpdateRecruitmentStatus = createMutationHook<
   UpdateRecruitmentStatusRequest,
   void
 >({
-  domain: `${DOMAIN}/status`,
+  path: "/status",
   method: "patch"
 });

--- a/packages/api/src/reviews/index.ts
+++ b/packages/api/src/reviews/index.ts
@@ -1,4 +1,4 @@
-import type {
+﻿import type {
   ReviewDetailResponse,
   CreateReviewRequest,
   ReviewQuestionsResponse,
@@ -8,24 +8,22 @@ import type {
   ReviewCountQueryParams,
   MyReviewsResponse
 } from "./types";
-import {
-  createQueryHook,
-  createMutationHook,
-  createIdMutationHook
-} from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 import { reviewsKeys } from "./keys";
 
 const DOMAIN = "/reviews";
+const { createQueryHook, createMutationHook, createIdMutationHook } =
+  createDomainApi(DOMAIN);
 
 export { reviewsKeys };
 
 export const useReviewDetail = createQueryHook<string, ReviewDetailResponse>({
-  domain: reviewId => `${DOMAIN}/${reviewId}`,
+  path: reviewId => `/${reviewId}`,
   queryKey: reviewsKeys.reviewDetail
 });
 
 export const useCreateReview = createMutationHook<CreateReviewRequest, void>({
-  domain: DOMAIN,
+  path: "/",
   method: "post"
 });
 
@@ -33,30 +31,32 @@ export const useReviewQuestions = createQueryHook<
   void,
   ReviewQuestionsResponse
 >({
-  domain: `${DOMAIN}/questions`,
+  path: "/questions",
   queryKey: reviewsKeys.reviewQuestions
 });
 
 export const useDeleteReview = createIdMutationHook<void, void>({
-  domain: DOMAIN,
+  path: "/",
   method: "delete"
 });
 
-export const useReviewList = (params?: ReviewListQueryParams) => {
-  return createQueryHook<ReviewListQueryParams, ReviewListResponse>({
-    domain: DOMAIN,
-    queryKey: () => reviewsKeys.reviewList(params)
-  })(params);
-};
+export const useReviewList = createQueryHook<
+  ReviewListQueryParams,
+  ReviewListResponse
+>({
+  path: "/",
+  queryKey: reviewsKeys.reviewList
+});
 
-export const useReviewCount = (params?: ReviewCountQueryParams) => {
-  return createQueryHook<ReviewCountQueryParams, ReviewCountResponse>({
-    domain: `${DOMAIN}/count`,
-    queryKey: () => reviewsKeys.reviewCount(params)
-  })(params);
-};
+export const useReviewCount = createQueryHook<
+  ReviewCountQueryParams,
+  ReviewCountResponse
+>({
+  path: "/count",
+  queryKey: reviewsKeys.reviewCount
+});
 
 export const useMyReviews = createQueryHook<void, MyReviewsResponse>({
-  domain: `${DOMAIN}/my`,
+  path: "/my",
   queryKey: reviewsKeys.myReviews
 });

--- a/packages/api/src/students/index.ts
+++ b/packages/api/src/students/index.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+﻿import { useMutation, useQuery } from "@tanstack/react-query";
 import type {
   StudentMyResponse,
   UpdateStudentProfileRequest,
@@ -8,16 +8,17 @@ import type {
   ChangePwRequest
 } from "./types";
 import type { QueryOptions, MutationOptions } from "@/QueryProvider";
-import { createQueryHook, createMutationHook } from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 import { instance } from "@/instance";
 import { studentsKeys } from "./keys";
 
 const DOMAIN = "/students";
+const { createQueryHook, createMutationHook } = createDomainApi(DOMAIN);
 
 export { studentsKeys };
 
 export const useStudentMy = createQueryHook<void, StudentMyResponse>({
-  domain: `${DOMAIN}/my`,
+  path: "/my",
   queryKey: studentsKeys.studentMy
 });
 
@@ -27,7 +28,7 @@ export const useStudentExists = (
   options?: QueryOptions<boolean>
 ) => {
   return useQuery({
-    queryKey: studentsKeys.studentExists(gcn, name),
+    queryKey: studentsKeys.studentExists({ gcn, name }),
     queryFn: async () => {
       try {
         await instance.get(`${DOMAIN}/exists`, { params: { gcn, name } });
@@ -44,7 +45,7 @@ export const useUpdateStudentProfile = createMutationHook<
   UpdateStudentProfileRequest,
   void
 >({
-  domain: `${DOMAIN}/profile`,
+  path: "/profile",
   method: "patch"
 });
 
@@ -52,7 +53,7 @@ export const useStudentSignup = createMutationHook<
   StudentSignupRequest,
   StudentSignupResponse
 >({
-  domain: DOMAIN,
+  path: "/",
   method: "post"
 });
 
@@ -60,12 +61,12 @@ export const useChangePwByEmail = createMutationHook<
   ChangePwByEmailRequest,
   void
 >({
-  domain: `${DOMAIN}/forgotten_password`,
+  path: "/forgotten_password",
   method: "patch"
 });
 
 export const useChangePw = createMutationHook<ChangePwRequest, void>({
-  domain: `${DOMAIN}/password`,
+  path: "/password",
   method: "patch"
 });
 

--- a/packages/api/src/students/keys.ts
+++ b/packages/api/src/students/keys.ts
@@ -1,4 +1,7 @@
 export const studentsKeys = {
   studentMy: () => ["student-my"],
-  studentExists: (gcn?: string, name?: string) => ["student-exists", gcn, name]
+  studentExists: (params?: { gcn?: string; name?: string }) => [
+    "student-exists",
+    params
+  ]
 } as const;

--- a/packages/api/src/users/index.ts
+++ b/packages/api/src/users/index.ts
@@ -1,9 +1,10 @@
 import type { LoginRequest, LoginResponse } from "./types";
-import { createMutationHook } from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 
 const DOMAIN = "/users";
+const { createMutationHook } = createDomainApi(DOMAIN);
 
 export const useLogin = createMutationHook<LoginRequest, LoginResponse>({
-  domain: `${DOMAIN}/login`,
+  path: "/login",
   method: "post"
 });

--- a/packages/api/src/winter-intern/index.ts
+++ b/packages/api/src/winter-intern/index.ts
@@ -1,16 +1,17 @@
-import { useQuery } from "@tanstack/react-query";
+﻿import { useQuery } from "@tanstack/react-query";
 import type { WinterInternStatusResponse } from "./types";
 import type { QueryOptions } from "@/QueryProvider";
-import { createMutationHook } from "@/create-hook";
+import { createDomainApi } from "@/create-hook";
 import { instance } from "@/instance";
 import { winterInternKeys } from "./keys";
 
 const DOMAIN = "/winter-intern";
+const { createMutationHook } = createDomainApi(DOMAIN);
 
 export { winterInternKeys };
 
 export const useToggleWinterIntern = createMutationHook<void, void>({
-  domain: DOMAIN,
+  path: "/",
   method: "patch"
 });
 


### PR DESCRIPTION
## 작업 내용 설명
- API 훅 구조를 createDomainApi(domain) 기반으로 통일
- 라우터 prefetch/인라인 loader 정리 및 페이지 loader 연결
- query key 인자 규칙 정리

## 주요 변경 사항
- packages/api 훅 팩토리 구조 개편 (createDomainApi 도입)
- 단일 식별자 제외 query key를 object 기반으로 변경
- query.prefetch 제거 후 useXxx.prefetch 사용으로 마이그레이션

## 체크리스트
- [x] 빌드 되나요? (`yarn build`)
- [x] 콘솔에 에러 없나요? (`yarn dev`)
- [x] 목표한 부분만 수정했나요? (사이드 이펙트 체크)

## 해결 이슈
- resolved #101 